### PR TITLE
Collection Completed changes

### DIFF
--- a/commands/card.js
+++ b/commands/card.js
@@ -1,5 +1,4 @@
 const {cmd}                 = require('../utils/cmd')
-const {bestColMatch}        = require('../modules/collection')
 const {fetchCardTags}       = require('../modules/tag')
 const colors                = require('../utils/colors')
 const msToTime              = require('pretty-ms')
@@ -10,6 +9,11 @@ const {
     claimCost, 
     promoClaimCost
 } = require('../utils/tools')
+
+const {
+    bestColMatch,
+    completed
+} = require('../modules/collection')
 
 const {
     evalCard, 
@@ -97,6 +101,9 @@ cmd('claim', 'cl', async (ctx, user, ...args) => {
         else card = _.sample(colCards.filter(x => x.level < 5 && !x.excluded))
 
         const count = addUserCard(user, card.id)
+
+        await completed(ctx, user, card)
+
         cards.push({count, boostdrop, card: _.clone(card)})
     }
     

--- a/commands/collection.js
+++ b/commands/collection.js
@@ -33,7 +33,7 @@ cmd('col', async (ctx, user, ...args) => {
 
     const pages = ctx.pgn.getPages(cols.map(x => {
         const complete = user.completedcols.find(y => x.id === y.id)
-        return `${complete? `[${complete.amount}${ctx.symbols.star}] ` : ''}**${x.name}** (${x.id})`
+        return `${complete && complete.amount > 0? `[${complete.amount}${ctx.symbols.star}] ` : ''}**${x.name}** (${x.id})`
     }))
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
@@ -60,7 +60,7 @@ cmd(['col', 'info'], async (ctx, user, ...args) => {
     resp.push(`Overall cards: **${colCards.length}**`)
     resp.push(`You have: **${userCards.length} (${((userCards.length / colCards.length) * 100).toFixed(2)}%)**`)
 
-    if(clout)
+    if(clout && clout.amount > 0)
         resp.push(`Your clout: **${new Array(clout.amount + 1).join('★')}** (${clout.amount})`)
 
     resp.push(`Aliases: **${col.aliases.join(" **|** ")}**`)

--- a/commands/hero.js
+++ b/commands/hero.js
@@ -325,7 +325,7 @@ cmd(['hero', 'submit'], async (ctx, user, arg1) => {
 
     const recent = submissions.find(x => x.submitted > past)
     if(recent)
-        return ctx.reply(user, `you can submit new hero in **${msToTime(recent.submitted - past, {compact: true})}**`, 'red')
+        return ctx.reply(user, `you can submit a new hero in **${msToTime(recent.submitted - past, {compact: true})}**`, 'red')
 
     let char
     try {
@@ -333,15 +333,15 @@ cmd(['hero', 'submit'], async (ctx, user, arg1) => {
     } catch { }
 
     if(!char)
-        return ctx.reply(user, `cannot find a valid character on this URL`, 'red')
+        return ctx.reply(user, `cannot find a valid character at this URL`, 'red')
 
     if(!char.animeography[0])
-        return ctx.reply(user, `seems like this character doesn't have any asociated anime.
+        return ctx.reply(user, `seems like this character doesn't have any associated anime.
             Only characters with valid animeography are allowed`, 'red')
 
     const embed = { 
         title: `Submitting a hero`,
-        description: `you are about to submit **${char.name}** from **${char.animeography[0].name}**.
+        description: `You are about to submit **${char.name}** from **${char.animeography[0].name}**.
         > It may take up to a week to review the character. You will keep your current hero while the submission is being processed.
         Proceed?`,
         image: { url: char.image_url }

--- a/commands/user.js
+++ b/commands/user.js
@@ -267,7 +267,7 @@ cmd('profile', async (ctx, user, ...args) => {
     }, user.discord_id)
 }).access('dm')
 
-cmd('diff', async (ctx, user, ...args) => {
+cmd('diff', 'dif', async (ctx, user, ...args) => {
     const newArgs = parseArgs(ctx, args)
 
     if(!newArgs.ids[0])

--- a/modules/auction.js
+++ b/modules/auction.js
@@ -3,6 +3,10 @@ const {generateNextId}  = require('../utils/tools')
 const {fetchOnly}       = require('./user')
 
 const {
+    completed
+} = require('../modules/collection')
+
+const {
     check_effect
 } = require('../modules/effect')
 
@@ -115,6 +119,8 @@ const finish_aucs = async (ctx, now) => {
         lastBidder.exp += (auc.highbid - auc.price) + tback
         author.exp += auc.price
         addUserCard(lastBidder, auc.card)
+        const aucCard = ctx.cards[auc.card]
+        await completed(ctx, lastBidder, aucCard)
         await lastBidder.save()
         await author.save()
         await from_auc(auc, author, lastBidder)

--- a/modules/collection.js
+++ b/modules/collection.js
@@ -1,5 +1,6 @@
 /* functions */
 
+
 const byAlias = (ctx, name) => {
     const regex = new RegExp(name, 'gi')
     return ctx.collections.filter(x => x.aliases.some(y => regex.test(y)))
@@ -10,14 +11,51 @@ const bestColMatch = (ctx, name) => {
 	return c.sort((a, b) => a.id.length - b.id.length)[0]
 }
 
+/*
+    To utilize this elsewhere, you'll need to pass it the ctx, user, and full card(ctx.cards[card.id]).
+    userCards is mainly a copy/paste of mapUserCards from module Cards, but it would break on require so I stole it since it's only 1 line
+ */
+const completed = async (ctx, user, card) => {
+    const colCards = ctx.cards.filter(x => x.col === card.col && x.level < 5)
+
+    const message = "You just completed the _"+ card.col +"_ collection!\n"+
+        "You now have the option to reset this collection in exchange for a clout star. One copy of each card will be consumed if you do. To proceed, type:\n"+
+        "`->col reset "+ card.col +"`"
+
+    let userCards = user.cards.filter(x => x.id < ctx.cards.length).map(x => Object.assign({}, ctx.cards[x.id], x))
+
+    if(userCards.length < colCards.length) {
+        return false
+    }
+
+    const completedCol = user.completedcols.find(x => x.id === card.col)
+
+    if (!completedCol) {
+        await ctx.direct(user, message)
+        user.completedcols.push({ id: card.col, notified: true })
+        user.markModified('completedcols')
+    }
+    else {
+        if (!completedCol.notified) {
+            await ctx.direct(user, message)
+            completedCol.notified = true
+            user.markModified('completedcols')
+        }
+    }
+    return
+}
+
 const reset = async (ctx, user, col) => {
     const completed = user.completedcols.find(x => x.id === col.id)
     const legendary = ctx.cards.find(x => x.col === col.id && x.level === 5)
 
-    if(completed)
+    if(completed) {
         completed.amount++
-    else
-        user.completedcols.push({ id: col.id, amount: 1 })
+        completed.notified = false
+    }
+    else {
+        user.completedcols.push({id: col.id, amount: 1})
+    }
     user.markModified('completedcols')
 
     user.cards.map(x => { 
@@ -38,8 +76,11 @@ const reset = async (ctx, user, col) => {
         ${legendary? `Legendary card ticket was added to your inventory. Use it to draw **${col.id} legendary card**!` : ''}`)
 }
 
+
+
 module.exports = {
-    byAlias, 
+    byAlias,
     bestColMatch,
+    completed,
     reset
 }


### PR DESCRIPTION
Bot will now PM user when they complete a collection. It sets collection as completed without an amount so it can be listed in ->col -completed, and displays have been changed to not display when clout amount is 0/undefined.

Fixed confirming showing the buyer as the from and to, which also fixes the unhandledpromiserejectionwarning in transactions.

Forge shows when you get a duplicate card again.

Re-added dif as an alias to diff

Minor spelling/grammar changes in hero