### PR TITLE
Fixes col reset, adds ->trans auction 

### DIFF
--- a/collections/audit.js
+++ b/collections/audit.js
@@ -15,4 +15,5 @@ module.exports = model('Audit', {
     report_type:    { type: Number, default: 0 },
     card:           [],
 
+    time:           { type: Date },
 })

--- a/collections/auditAucSell.js
+++ b/collections/auditAucSell.js
@@ -1,0 +1,14 @@
+const {model, Schema} = require('mongoose')
+
+module.exports = model('AuditAucSell', {
+    user:           { type: String },
+    name:           { type: String },
+
+    audited:        { type: Boolean, default: false },
+
+    sold:           { type: Number, default: 0 },
+    unsold:         { type: Number, default: 0 },
+
+    time:           { type: Date },
+
+})

--- a/collections/index.js
+++ b/collections/index.js
@@ -8,4 +8,5 @@ module.exports = {
     Hero: require('./hero'),
     Cardinfo: require('./cardinfo'),
     Audit: require('./audit'),
+    AuditAucSell: require('./auditAucSell'),
 }

--- a/commands/transaction.js
+++ b/commands/transaction.js
@@ -97,6 +97,44 @@ cmd(['trans', 'sends'], 'sends', async (ctx, user) => {
     })
 })
 
+cmd(['trans', 'auction'], async (ctx, user, arg1) => {
+    let auth, list
+    switch (arg1) {
+        case 'gets' :
+            list = await Transaction.find({
+                to_id: user.discord_id ,
+                status: 'auction'
+            }).sort({ time: -1 })
+            auth = `${user.username}, your incoming auction transactions (${list.length} results)`
+            break
+        case 'sends' :
+            list = await Transaction.find({
+                from_id: user.discord_id,
+                status: 'auction'
+            }).sort({ time: -1 })
+            auth = `${user.username}, your outgoing auction transactions (${list.length} results)`
+            break
+        default:
+            list = await Transaction.find({
+                $or: [{ to_id: user.discord_id }, { from_id: user.discord_id }],
+                status: 'auction'
+            }).sort({ time: -1 })
+            auth = `${user.username}, your auction transactions (${list.length} results)`
+    }
+
+    if(list.length == 0)
+        return ctx.reply(user, `you don't have any recent auction transactions`)
+
+    return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
+        pages: paginate_trslist(ctx, user, list),
+        buttons: ['back', 'forward'],
+        embed: {
+            author: { name: auth },
+            color: colors.green,
+        }
+    })
+})
+
 cmd(['trans', 'info'], async (ctx, user, arg1) => {
     const trs = await Transaction.findOne({ id: arg1 })
 

--- a/commands/transaction.js
+++ b/commands/transaction.js
@@ -97,29 +97,29 @@ cmd(['trans', 'sends'], 'sends', async (ctx, user) => {
     })
 })
 
-cmd(['trans', 'auction'], async (ctx, user, arg1) => {
-    let auth, list
+cmd(['trans', 'auction'], ['trans', 'auc'], async (ctx, user, arg1) => {
+    let authorText, list
     switch (arg1) {
         case 'gets' :
             list = await Transaction.find({
                 to_id: user.discord_id ,
                 status: 'auction'
             }).sort({ time: -1 })
-            auth = `${user.username}, your incoming auction transactions (${list.length} results)`
+            authorText = `${user.username}, your incoming auction transactions (${list.length} results)`
             break
         case 'sends' :
             list = await Transaction.find({
                 from_id: user.discord_id,
                 status: 'auction'
             }).sort({ time: -1 })
-            auth = `${user.username}, your outgoing auction transactions (${list.length} results)`
+            authorText = `${user.username}, your outgoing auction transactions (${list.length} results)`
             break
         default:
             list = await Transaction.find({
                 $or: [{ to_id: user.discord_id }, { from_id: user.discord_id }],
                 status: 'auction'
             }).sort({ time: -1 })
-            auth = `${user.username}, your auction transactions (${list.length} results)`
+            authorText = `${user.username}, your auction transactions (${list.length} results)`
     }
 
     if(list.length == 0)
@@ -129,7 +129,7 @@ cmd(['trans', 'auction'], async (ctx, user, arg1) => {
         pages: paginate_trslist(ctx, user, list),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: auth },
+            author: { name: authorText },
             color: colors.green,
         }
     })

--- a/commands/user.js
+++ b/commands/user.js
@@ -232,6 +232,7 @@ cmd('profile', async (ctx, user, ...args) => {
             color: colors.red
         })
 
+    const completedSum = user.completedcols.map(x => x.id).length
     const cloutsum = user.completedcols.map(x => x.amount).reduce((a, b) => a + b, 0)
     const stamp = user._id.getTimestamp()
     const cards = mapUserCards(ctx, user)
@@ -242,8 +243,10 @@ cmd('profile', async (ctx, user, ...args) => {
     resp.push(`Cards: **${user.cards.length}** | Stars: **${cards.map(x => x.level).reduce((a, b) => a + b, 0)}**`)
     resp.push(`In game since: **${stampString}** (${msToTime(new Date() - stamp, {compact: true})})`)
 
-    if(cloutsum > 0) {
+    if(completedSum > 0) {
         resp.push(`Completed collections: **${user.completedcols.length}**`)
+    }
+    if(cloutsum > 0) {
         resp.push(`Overall clout: **${cloutsum}**`)
     }
 

--- a/commands/user.js
+++ b/commands/user.js
@@ -232,7 +232,7 @@ cmd('profile', async (ctx, user, ...args) => {
             color: colors.red
         })
 
-    const completedSum = user.completedcols.map(x => x.id).length
+    const completedSum = user.completedcols.length
     const cloutsum = user.completedcols.map(x => x.amount).reduce((a, b) => a + b, 0)
     const stamp = user._id.getTimestamp()
     const cards = mapUserCards(ctx, user)

--- a/modules/collection.js
+++ b/modules/collection.js
@@ -32,7 +32,7 @@ const completed = async (ctx, user, card) => {
 
     if (!completedCol) {
         await ctx.direct(user, message)
-        user.completedcols.push({ id: card.col, notified: true })
+        user.completedcols.push({ id: card.col, amount: 0, notified: true })
         user.markModified('completedcols')
     }
     else {
@@ -50,11 +50,18 @@ const reset = async (ctx, user, col) => {
     const legendary = ctx.cards.find(x => x.col === col.id && x.level === 5)
 
     if(completed) {
-        completed.amount++
+        if(completed.amount){
+            completed.amount++
+
+        }else{
+            completed.amount = 1
+
+        }
+
         completed.notified = false
     }
     else {
-        user.completedcols.push({id: col.id, amount: 1})
+        user.completedcols.push({id: col.id, amount: 1, notified: false})
     }
     user.markModified('completedcols')
 

--- a/modules/collection.js
+++ b/modules/collection.js
@@ -50,14 +50,7 @@ const reset = async (ctx, user, col) => {
     const legendary = ctx.cards.find(x => x.col === col.id && x.level === 5)
 
     if(completed) {
-        if(completed.amount){
-            completed.amount++
-
-        }else{
-            completed.amount = 1
-
-        }
-
+        completed.amount = completed.amount + 1 || 1
         completed.notified = false
     }
     else {

--- a/staticdata/achievements.js
+++ b/staticdata/achievements.js
@@ -86,7 +86,7 @@ module.exports = [
         name: 'Snap your fingers',
         desc: 'Reset collection for the first time',
         actions: ['col', 'collection'],
-        check: (ctx, user) => user.completedcols.length > 0,
+        check: (ctx, user) => user.completedcols.map(x => x.amount).sort((a, b) => b.amount - a.amount)[0] > 0,
         resolve: (ctx, user) => {
             user.xp += 2
             user.exp += 800

--- a/staticdata/achievements.js
+++ b/staticdata/achievements.js
@@ -86,7 +86,7 @@ module.exports = [
         name: 'Snap your fingers',
         desc: 'Reset collection for the first time',
         actions: ['col', 'collection'],
-        check: (ctx, user) => user.completedcols.map(x => x.amount).sort((a, b) => b.amount - a.amount)[0] > 0,
+        check: (ctx, user) => user.completedcols.sort((a, b) => b.amount - a.amount)[0] > 0,
         resolve: (ctx, user) => {
             user.xp += 2
             user.exp += 800

--- a/staticdata/help.json
+++ b/staticdata/help.json
@@ -592,15 +592,15 @@
             },
             {
                 "title": "->cards ># or ->cards <#",
-                "description": "Sort by amount of copies greater than or less than number\nTo do <3, you need to type `\\<3`"
+                "description": "Filter by amount of copies greater than or less than number\nIf <3 doesn't work, you need to type `\\<3`"
             },
             {
                 "title": "->cards >=# or ->cards <=#",
-                "description": "Sort by amount of copies equal to or greater than or equal to or less than number"
+                "description": "Filter by amount of copies equal to or greater than or equal to or less than number"
             },
             {
                 "title": "->cards =#",
-                "description": "Sort for exact amount of copies you own"
+                "description": "Filter for exact amount of copies you own"
             }
         ]
     },


### PR DESCRIPTION
Made a fix for col reset adding a null for number if it is your first reset. Re-worded help for query operators, achievement now looks for a col reset of amount >0, instead of length >0. Profile now lists completed cols and clouted cols at different times, in line with the new completed definition