### PR TITLE
Audit Commands Expanded

### DIFF
--- a/collections/audit.js
+++ b/collections/audit.js
@@ -1,9 +1,11 @@
 const {model, Schema} = require('mongoose')
 
 module.exports = model('Audit', {
+    audit_id:       { type: String },
     id:             { type: String },
     transid:        { type: String },
     user:           { type: String },
+    closedBy:       { type: String },
 
     audited:        { type: Boolean, default: false },
 
@@ -16,4 +18,5 @@ module.exports = model('Audit', {
     card:           [],
 
     time:           { type: Date },
+
 })

--- a/collections/auditAucSell.js
+++ b/collections/auditAucSell.js
@@ -1,17 +1,12 @@
 const {model, Schema} = require('mongoose')
 
 module.exports = model('AuditAucSell', {
-    audit_id:       { type: String },
     user:           { type: String },
     name:           { type: String },
-
-    audited:        { type: Boolean, default: false },
 
     sold:           { type: Number, default: 0 },
     unsold:         { type: Number, default: 0 },
 
     time:           { type: Date },
-
-    closedBy:       { type: String },
 
 })

--- a/collections/auditAucSell.js
+++ b/collections/auditAucSell.js
@@ -1,6 +1,7 @@
 const {model, Schema} = require('mongoose')
 
 module.exports = model('AuditAucSell', {
+    audit_id:       { type: String },
     user:           { type: String },
     name:           { type: String },
 
@@ -10,5 +11,7 @@ module.exports = model('AuditAucSell', {
     unsold:         { type: Number, default: 0 },
 
     time:           { type: Date },
+
+    closedBy:       { type: String },
 
 })

--- a/commands/admin.js
+++ b/commands/admin.js
@@ -198,8 +198,12 @@ pcmd(['admin'], ['sudo', 'embargo'], async (ctx, user, ...args) => {
         if(lift) {
             target.ban.embargo = false
             rpl.push(`${target.username} has been lifted`)
-            await ctx.direct(target, "Your embargo has been lifted, you may now return to normal bot usage. Please try to follow the rules, they can easily be found at \`->rules\`")
             await target.save()
+            try {
+                await ctx.direct(target, "Your embargo has been lifted, you may now return to normal bot usage. Please try to follow the rules, they can easily be found at \`->rules\`")
+            } catch(e) {
+                rpl.push(`\n ${target.username} doesn't allow PMs from the bot, so a message was not sent`)
+            }
         } else {
             target.ban? target.ban.embargo = true: target.ban = {embargo: true}
             rpl.push(`${target.username} has been embargoed`)

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -316,7 +316,7 @@ pcmd(['admin', 'auditor'], ['audit', 'complete'], ['audit', 'confirm'], async (c
 
 pcmd(['admin', 'auditor'], ['audit', 'closed'], async (ctx, user, arg) => {
     if (ctx.msg.channel.id != ctx.audit['channel'])
-        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+        return ctx.reply(user, 'this command can only be run in an audit channel.', 'red')
 
     const closedAudits = await Audit.find({audited: true}).sort({ _id: -1})
 

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -10,6 +10,7 @@ const {
     formatAucBidList,
     paginate_auditReports,
     paginate_guildtrslist,
+    paginate_closedAudits,
     parseAuditArgs
 }   = require("../modules/audit");
 
@@ -17,7 +18,8 @@ const {
     Audit,
     AuditAucSell,
     Auction,
-    Transaction
+    Transaction,
+    User
 }     = require('../collections')
 
 
@@ -25,54 +27,60 @@ pcmd(['admin', 'auditor'], ['fraud', 'report'], async (ctx, user, ...args) => {
     if (ctx.msg.channel.id != ctx.audit['channel'])
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
-    let switchType = args.shift()
 
-    switch(switchType) {
-        case '1':
-            let overSell = await AuditAucSell.find({sold: {$gt:5}}).sort({sold: -1})
+    return ctx.reply(user, `**__Choose a fraud report__**
+                            Fraud Report 1: Lists users who have more auction sales than returns
+                            Fraud Report 2: Lists overpriced auctions
+                            Fraud Report 3: Lists users who sold a card on auction and then bought the card back`)
 
-            return  ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-                pages: paginate_auditReports(ctx, user, overSell, 1),
-                buttons: ['back', 'forward'],
-                embed: {
-                    author: { name: `${user.username}, open report 2 audits: (${overSell.length} results)` },
-                    color: colors.blue,
-                }
-            })
+})
 
-        case '2':
+pcmd(['admin', 'auditor'], ['fraud', 'report', '1'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
-            let overPrice = (await Audit.find({ audited: false, report_type: 2 }).sort({price_over : -1}))
+    let overSell = await AuditAucSell.find({sold: {$gt:5}}).sort({sold: -1})
 
-            return  ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-                pages: paginate_auditReports(ctx, user, overPrice, 2),
-                buttons: ['back', 'forward'],
-                embed: {
-                    author: { name: `${user.username}, open report 2 audits: (${overPrice.length} results)` },
-                    color: colors.blue,
-                }
-            })
+    return  ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
+        pages: paginate_auditReports(ctx, user, overSell, 1),
+        buttons: ['back', 'forward'],
+        embed: {
+            author: { name: `${user.username}, open report 1 audits: (${overSell.length} results)` },
+            color: colors.blue,
+        }
+    })
+})
 
-        case '3':
-            let buybacks = await Audit.find({audited: false, report_type: 3}).sort({price: -1})
+pcmd(['admin', 'auditor'], ['fraud', 'report', '2'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
-            return  ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-                pages: paginate_auditReports(ctx, user, buybacks, 3),
-                buttons: ['back', 'forward'],
-                embed: {
-                    author: { name: `${user.username}, open report 3 audits: (${buybacks.length} results)` },
-                    color: colors.blue,
-                }
-            })
+    let overPrice = (await Audit.find({ audited: false, report_type: 2 }).sort({price_over : -1}))
 
-        default:
-            return ctx.reply(user, `**__Choose a fraud report__**
-                                    Fraud Report 1: Lists users who have more auction sales than returns
-                                    Fraud Report 2: Lists overpriced auctions
-                                    Fraud Report 3: Lists users who sold a card on auction and then bought the card back`)
+    return  ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
+        pages: paginate_auditReports(ctx, user, overPrice, 2),
+        buttons: ['back', 'forward'],
+        embed: {
+            author: { name: `${user.username}, open report 2 audits: (${overPrice.length} results)` },
+            color: colors.blue,
+        }
+    })
+})
 
-    }
+pcmd(['admin', 'auditor'], ['fraud', 'report', '3'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
+    let buybacks = await Audit.find({audited: false, report_type: 3}).sort({price: -1})
+
+    return  ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
+        pages: paginate_auditReports(ctx, user, buybacks, 3),
+        buttons: ['back', 'forward'],
+        embed: {
+            author: { name: `${user.username}, open report 3 audits: (${buybacks.length} results)` },
+            color: colors.blue,
+        }
+    })
 })
 
 pcmd(['admin', 'auditor'], ['audit'], async (ctx, user, ...args) => {
@@ -83,13 +91,15 @@ pcmd(['admin', 'auditor'], ['audit'], async (ctx, user, ...args) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let arg = parseAuditArgs(ctx, args)
 
     let search
     const auditedUser = await fetchOnly(arg.id)
 
     if (!arg.id)
-        return ctx.reply(user, `please submit a valid guild ID`, 'red')
+        return ctx.reply(user, `please submit a valid user ID`, 'red')
 
     if (arg.auction && arg.gets) {
         search = {to_id: auditedUser.discord_id, status: 'auction'}
@@ -126,6 +136,8 @@ pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'guild'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let arg = parseAuditArgs(ctx, args)
     let search
     if (!arg.id)
@@ -150,6 +162,8 @@ pcmd(['admin', 'auditor'], ['audit', 'guild'], async (ctx, user, ...args) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'trans'], async (ctx, user, ...arg) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let trans = await Transaction.findOne({id: arg[0]})
 
     if (!trans)
@@ -161,11 +175,11 @@ pcmd(['admin', 'auditor'], ['audit', 'trans'], async (ctx, user, ...arg) => {
     const resp = []
     resp.push(`Card: ${formatName(card)}`)
     resp.push(`Price: **${trans.price}** ${ctx.symbols.tomato}`)
-    resp.push(`From: **${trans.from}**`)
-    resp.push(`To: **${trans.to}**`)
+    resp.push(`From: **${trans.from}** \`${trans.from_id}\``)
+    resp.push(`To: **${trans.to}** \`${trans.to_id}\``)
 
     if(trans.guild) {
-        resp.push(`On server: **${trans.guild}**`)
+        resp.push(`On server: **${trans.guild}** \`${trans.guild_id}\``)
         resp.push(`Status: **\`${ch_map[trans.status]}\` ${trans.status}**`)
     } else {
         resp.push(`${ch_map[trans.status]} This is an **auction** transaction`)
@@ -182,13 +196,32 @@ pcmd(['admin', 'auditor'], ['audit', 'trans'], async (ctx, user, ...arg) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'warn'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let arg = parseAuditArgs(ctx, args)
     let warnedUser = await fetchOnly(arg.id)
-    await ctx.direct(warnedUser, arg.extraArgs.join(` `))
+
+    if (!warnedUser)
+        return ctx.reply(user, `user with ID ${arg.id} not found`, 'red')
+
+    try {
+        const ch = await ctx.bot.getDMChannel(arg.id)
+        let embed = {
+            title: "**Rule Violation Warning**",
+            description: `**${warnedUser.username}**, ${arg.extraArgs.join(" ")}`,
+            color: colors['yellow']
+        }
+        await ctx.send(ch.id, embed, user.discord_id)
+    } catch(e) {
+        return ctx.reply(user, `insufficient permissions to send a DM message. Warning message not sent.`, 'red')
+    }
+
     return ctx.reply(user, "Warning message sent")
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'auc'], ['audit', 'auction'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     const auc = await Auction.findOne({ id: args[0] })
 
     if(!auc)
@@ -199,7 +232,7 @@ pcmd(['admin', 'auditor'], ['audit', 'auc'], ['audit', 'auction'], async (ctx, u
     const timediff = msToTime(auc.expires - new Date(), {compact: true})
 
     const resp = []
-    resp.push(`Seller: **${author.username}**`)
+    resp.push(`Seller: **${author.username}** \`${author.discord_id}\``)
     resp.push(`Price: **${auc.price}** ${ctx.symbols.tomato}`)
     resp.push(`Card: ${formatName(card)}`)
     resp.push(`Card value: **${await evalCard(ctx, card)}** ${ctx.symbols.tomato}`)
@@ -230,4 +263,72 @@ pcmd(['admin', 'auditor'], ['audit', 'auc'], ['audit', 'auction'], async (ctx, u
         buttons: ['back', 'forward'],
         switchPage: (data) => data.embed.fields[0] = { name: `Auction Bids`, value: data.pages[data.pagenum] }
     }, user.discord_id)
+})
+
+pcmd(['admin', 'auditor'], ['audit', 'find'], async (ctx, user, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+    let arg = parseAuditArgs(ctx, args)
+    if (!arg.id)
+        return ctx.reply(user, `please submit a valid user ID`, 'red')
+
+    const findUser = await User.findOne({discord_id: arg.id})
+
+    if (findUser.length == 0)
+        return ctx.reply(user, 'no user found with that ID', 'red')
+
+    let effects = findUser.effects.map(x => x.id)
+
+    let embed = {
+        author: {name: `${user.username} here is the info for ${findUser.username}`},
+        description: `**${findUser.username}** \`${findUser.discord_id}\`
+                      Tomatoes: **${findUser.exp}${ctx.symbols.tomato}** 
+                      Vials: **${findUser.vials}${ctx.symbols.vial}**
+                      Promo Currency: **${findUser.promoexp}**
+                      Last Daily: **${findUser.lastdaily}**
+                      Unique Cards: **${findUser.cards.length}**
+                      Completed Collections: **${findUser.completedcols? findUser.completedcols.length: 0}**
+                      Effects List: **${effects.length != 0? effects: 0}**
+                      __Daily Stats__: 
+                      Claims: **${findUser.dailystats.claims? findUser.dailystats.claims: 0}**, Bids: **${findUser.dailystats.bids? findUser.dailystats.bids: 0}** Auctions: **${findUser.dailystats['aucs']? findUser.dailystats['aucs']: 0}**`,
+        color: colors['green']
+    }
+    return ctx.send(ctx.msg.channel.id, embed, user.discord_id)
+})
+
+pcmd(['admin', 'auditor'], ['audit', 'complete'], ['audit', 'confirm'], async (ctx, user, arg) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+
+    if (!arg)
+        return ctx.reply(user, `please submit a valid audit ID`, 'red')
+
+    const auditEntry = await Audit.findOne({audit_id: arg, audited: false})
+    
+    if (!auditEntry)
+        return ctx.reply(user, `no audit record found with that ID or it is already completed`, `red`)
+
+    auditEntry.audited = true
+    auditEntry.closedBy = user.username
+    await auditEntry.save()
+    return ctx.reply(user, `audit record with ID ${arg} has been confirmed as audited`)
+})
+
+pcmd(['admin', 'auditor'], ['audit', 'closed'], async (ctx, user, arg) => {
+    if (ctx.msg.channel.id != ctx.audit['channel'])
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+
+    const closedAudits = await Audit.find({audited: true}).sort({ _id: -1})
+
+    if (closedAudits.length == 0)
+        return ctx.reply(user, 'No closed audits found', 'red')
+
+    return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
+        pages: paginate_closedAudits(ctx, user, closedAudits),
+        buttons: ['back', 'forward'],
+        embed: {
+            author: { name: `${user.username}, here are the closed audits. (${closedAudits.length} results)` },
+            color: colors.blue,
+        }
+    })
 })

--- a/modules/auction.js
+++ b/modules/auction.js
@@ -126,6 +126,8 @@ const finish_aucs = async (ctx, now) => {
         const eval = await evalCard(ctx, aucCard)
         if (auc.price > eval * 2) {
             const auditDB = await new Audit()
+            const last_audit = (await Audit.find().sort({ _id: -1 }))[0]
+            auditDB.audit_id = last_audit? generateNextId(last_audit.audit_id, 7) : generateNextId('aaaaaaa', 7)
             auditDB.id = auc.id
             auditDB.card = aucCard.name
             auditDB.bids = auc.bids.length
@@ -145,7 +147,7 @@ const finish_aucs = async (ctx, now) => {
             sellDB.time = new Date()
             await sellDB.save()
         }else {
-            await AuditAucSell.findOneAndUpdate({ user: author.discord_id, $inc: {sold: 1}})
+            await AuditAucSell.findOneAndUpdate({ user: author.discord_id}, {$inc: {sold: 1}})
         }
         // End audit logic
         await completed(ctx, lastBidder, aucCard)
@@ -165,7 +167,7 @@ const finish_aucs = async (ctx, now) => {
             sellDB.time = new Date()
             await sellDB.save()
         }else {
-            await AuditAucSell.findOneAndUpdate({ user: author.discord_id, $inc: {unsold: 1}})
+            await AuditAucSell.findOneAndUpdate({ user: author.discord_id}, {$inc: {unsold: 1}})
         }
         addUserCard(author, auc.card)
         await author.save()

--- a/modules/audit.js
+++ b/modules/audit.js
@@ -51,10 +51,19 @@ const paginate_guildtrslist = (ctx, user, list) => {
     return pages;
 }
 
+const paginate_closedAudits = (ctx, user, list) => {
+    const pages =[]
+    list.map((t, i) => {
+        if (i % 10 == 0) pages.push("")
+        pages[Math.floor(i/10)] += `${formatCompletedList(ctx, user, t)}\n`
+    })
+    return pages;
+}
+
 const format_overSell = (ctx, user, auc) => {
     let resp = ""
     let sellPerc = (auc.sold / (auc.sold + auc.unsold)) * 100
-    resp += `${auc.name}, \`${auc.user}\` has ${auc.sold} sold and ${auc.unsold} unsold auctions, Sell Percentage is ${sellPerc.toLocaleString('en-us', {maximumFractionDigits: 2})}%`
+    resp += `AuditID:\`${auc.audit_id}\` ${auc.name}, \`${auc.user}\` has ${auc.sold} sold and ${auc.unsold} unsold auctions, Sell% ${sellPerc.toLocaleString('en-us', {maximumFractionDigits: 2})}%`
 
     return resp;
 }
@@ -62,7 +71,7 @@ const format_overSell = (ctx, user, auc) => {
 const format_overPrice = (ctx, user, auc) => {
     let resp = ""
 
-    resp += `**${auc.id}** sold \`${auc.card}\` for ${auc.price_over.toLocaleString('en-us', {maximumFractionDigits: 2})}x eval of ${auc.eval} with ${auc.price} finishing in ${auc.bids} bids`
+    resp += `AuditID: \`${auc.audit_id}\` **${auc.id}** sold \`${auc.card}\` for ${auc.price_over.toLocaleString('en-us', {maximumFractionDigits: 2})}x eval of ${auc.eval} with ${auc.price} finishing in ${auc.bids} bids`
 
     return resp;
 }
@@ -87,6 +96,12 @@ const formatGuildTrsList = (ctx, user, gtrans) => {
 const formatAucBidList = (ctx, user, bids) => {
     let resp = ""
     resp += `${bids.bid}${ctx.symbols.tomato}, \`${bids.user}\`, ${bids.time}`
+    return resp;
+}
+
+const formatCompletedList = (ctx, user, audit) => {
+    let resp = ""
+    resp += `\`${audit.audit_id}\` closed by ${audit.closedBy}, Report Type ${audit.report_type}`
     return resp;
 }
 
@@ -123,6 +138,7 @@ const parseAuditArgs = (ctx, args) => {
 module.exports = {
     paginate_auditReports,
     paginate_guildtrslist,
+    paginate_closedAudits,
     parseAuditArgs,
     clean_audits,
     formatAucBidList,

--- a/modules/audit.js
+++ b/modules/audit.js
@@ -63,7 +63,7 @@ const paginate_closedAudits = (ctx, user, list) => {
 const format_overSell = (ctx, user, auc) => {
     let resp = ""
     let sellPerc = (auc.sold / (auc.sold + auc.unsold)) * 100
-    resp += `AuditID:\`${auc.audit_id}\` ${auc.name}, \`${auc.user}\` has ${auc.sold} sold and ${auc.unsold} unsold auctions, Sell% ${sellPerc.toLocaleString('en-us', {maximumFractionDigits: 2})}%`
+    resp += `${auc.name}, \`${auc.user}\` has ${auc.sold} sold and ${auc.unsold} unsold auctions, Sell% ${sellPerc.toLocaleString('en-us', {maximumFractionDigits: 2})}%`
 
     return resp;
 }

--- a/modules/transaction.js
+++ b/modules/transaction.js
@@ -91,6 +91,8 @@ const confirm_trs = async (ctx, user, trs_id) => {
         const auditCheck = await Auction.findOne({ author: transaction.to_id, card: card.id})
         if (auditCheck) {
             const auditDB = await new Audit()
+            const last_audit = (await Audit.find().sort({ _id: -1 }))[0]
+            auditDB.audit_id = last_audit? generateNextId(last_audit.audit_id, 7) : generateNextId('aaaaaaa', 7)
             auditDB.report_type = 3
             auditDB.transid = transaction.id
             auditDB.id = auditCheck.id

--- a/staticdata/help.json
+++ b/staticdata/help.json
@@ -630,11 +630,19 @@
             },
             {
                 "title": "Auction Bidding",
-                "description": "The only reason you should bid on an auction is if you want to collect that card or resell it to a collector."
+                "description": "Bidding on auctions for the express purpose of helping someone gain tomatoes is prohibited. This includes buying cards from someone on auction and re-selling it to them, bidding to drive the price higher for them, and more."
             },
             {
                 "title": "Multiple Accounts",
                 "description": "This is only allowed if your accounts do not interact with each other."
+            },
+            {
+                "title": "Tagging Bypass",
+                "description": "Attempts to bypass banned words in the tagging process is prohibited. Users found doing this repeatedly will be subject to tagging bans and/or 10,000 tomato fine.\nIf tags are found to be done from an alt, the 10,000 tomato fine will be subjected to the main account, as well as proper punishment for alt usage."
+            },
+            {
+                "title": "Tagging Guidelines",
+                "description": "We are looking for useful tags, not tags based on opinions. \nTag types we are looking for:\n- Character name(s) of pictured\n- Fandom name(s) pictured\n- Key descriptions: `Animal_ears, cat_ears, fox_girl, maid`\n- Word Separation with \\_: Kanna`_`Kamui\n\nTag types we are NOT looking for:\n- Cute X: `Cute girls, cute girl, cute boys, cute boy`\n- Best X: `Best Girl, Best Boy, Best Character etc.`\n- Worst X: `Same as above, replace best with worst`\n- No Word Separation: kannakamui"
             },
             {
                 "title": "Play nice",


### PR DESCRIPTION
**THIS WILL REQUIRE THE DELETION OF THE 2 CURRENT AUDIT COLLECTIONS**

Fraud reports are all their own commands now

Audits can be closed, and the list of closed audits can be viewed until timed deletion

Added ->audit find, complete/confirm, closed, 

Audits now get their own IDs to be closed and referenced with. 

Rules got updated with what has been discussed in discord. Rules may not be final.