### PR TITLE
Fixes for promo, achievements and help

### DIFF
--- a/collections/user.js
+++ b/collections/user.js
@@ -29,7 +29,8 @@ module.exports = model('User', {
     roles:              { type: Array, default: [] },
     ban:                {
         full:           {type: Boolean},
-        embargo:        {type: Boolean}
+        embargo:        {type: Boolean},
+        tags:           {type: Number}
     },
 
     lastcard:           { type: Number, default: -1 },

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -287,7 +287,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args)
     let effects = findUser.effects.map(x => x.id)
 
     const dailyStats = `
-    Claims: **${findUser.dailystats.claims ? findUser.dailystats.claims : 0}**, Bids: **${findUser.dailystats.bids ? findUser.dailystats.bids : 0}**, Auctions: **${findUser.dailystats['aucs'] ? findUser.dailystats['aucs'] : 0}**
+    Claims: **${findUser.dailystats.claims ? findUser.dailystats.claims : 0}** (+${findUser.dailystats.promoclaims ? findUser.dailystats.promoclaims : 0} Promo), Bids: **${findUser.dailystats.bids ? findUser.dailystats.bids : 0}**, Auctions: **${findUser.dailystats['aucs'] ? findUser.dailystats['aucs'] : 0}**
     Liq: **${findUser.dailystats.liquify ? findUser.dailystats.liquify : 0}**, Draw: **${findUser.dailystats['draw'] ? findUser.dailystats['draw'] : 0}**, Tags: **${findUser.dailystats.tags ? findUser.dailystats.tags : 0}**
     Forge1: **${findUser.dailystats['forge1'] ? findUser.dailystats['forge1'] : 0}**, Forge2: **${findUser.dailystats['forge2'] ? findUser.dailystats['forge2'] : 0}**, Forge3: **${findUser.dailystats['forge3'] ? findUser.dailystats['forge3'] : 0}**`
 

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -310,6 +310,9 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args)
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'find', 'trans'], withGlobalCards(async (ctx, user, cards, ...args) => {
+    if (ctx.msg.channel.id != ctx.audit.channel)
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+
     const list = await Transaction.find({
         $or: [{to_id: args[0].ids}, {from_id: args[0].ids}], card: { $in: cards.map(c => c.id) }
     }).sort({ time: -1 }).limit(100)
@@ -367,6 +370,7 @@ pcmd(['admin', 'auditor'], ['audit', 'closed'], async (ctx, user, arg) => {
 pcmd(['admin', 'auditor'], ['audit', 'list'], ['audit', 'li'], ['audit', 'cards'], ['audit', 'ls'], async (ctx, user, ...args) => {
     if (ctx.msg.channel.id != ctx.audit.channel)
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+    
     let arg = parseArgs(ctx, args)
     if (!arg.ids)
         return ctx.reply(user, `please submit a valid user ID`, 'red')

--- a/commands/card.js
+++ b/commands/card.js
@@ -66,6 +66,7 @@ cmd('claim', 'cl', async (ctx, user, ...args) => {
     const normalprice = promo? price : claimCost(user, 0, amount)
     const gbank = getBuilding(ctx, 'gbank')
     const curboosts = ctx.boosts.filter(x => x.starts < now && x.expires > now)
+    const activepromo = ctx.promos.find(x => x.starts < now && x.expires > now)
 
     if(amount > 10)
         return ctx.reply(user, `you can claim only **10** or less cards with one command`, 'red')
@@ -124,7 +125,7 @@ cmd('claim', 'cl', async (ctx, user, ...args) => {
             max++
     } else {
         user.exp -= price
-        user.promoexp += extra
+        activepromo? user.promoexp += extra :
         await user.updateOne({$inc: {'dailystats.claims': amount}})
         user.dailystats.claims = user.dailystats.claims + amount || amount
         while(claimCost(user, ctx.guild.tax, max) < user.exp)
@@ -154,7 +155,9 @@ cmd('claim', 'cl', async (ctx, user, ...args) => {
     fields.push({name: `Receipt`, value: `You spent **${price}** ${curr} in total
         You have **${Math.round(promo? user.promoexp : user.exp)}** ${curr} left
         You can claim **${max - 1}** more cards
-        Your next claim will cost **${promo? promoClaimCost(user, 1) : claimCost(user, ctx.guild.tax, 1)}** ${curr}`})
+        Your next claim will cost **${promo? promoClaimCost(user, 1) : claimCost(user, ctx.guild.tax, 1)}** ${curr}
+        ${activepromo && !promo? `You got **${extra}** ${activepromo.currency}
+        You now have **${user.promoexp}** ${activepromo.currency}` : ""}`})
     /*fields.push({name: `External view`, value:
         `[view your claimed cards here](http://noxcaos.ddns.net:3000/cards?type=claim&ids=${cards.map(x => x.card.id).join(',')})`})*/
 

--- a/commands/guild.js
+++ b/commands/guild.js
@@ -185,6 +185,9 @@ cmd(['guild', 'downgrade'], ['guild', 'down'], async (ctx, user, arg1) => {
     if(!building)
         return ctx.reply(user, `building with ID \`${arg1}\` not found`, 'red')
 
+    if (item.id == "castle" && building.level - 1 == 0)
+        return ctx.reply(user, `you cannot destroy your own castle!`, 'red')
+
     const question = `Do you want to downgrade **${item.name}** to level **${building.level - 1}**?
         It will be destroyed once reaches level 0`
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {

--- a/commands/user.js
+++ b/commands/user.js
@@ -139,6 +139,7 @@ cmd('daily', async (ctx, user) => {
         const quests = []
         const gbank = getBuilding(ctx, 'gbank')
         let amount = gbank? 500 : 300
+        const promoAmount = 500
         //let amount = 5000
         const tavern = getBuilding(ctx, 'tavern')
         const promo = ctx.promos.find(x => x.starts < now && x.expires > now)
@@ -153,6 +154,7 @@ cmd('daily', async (ctx, user) => {
         user.dailystats = {}
         user.exp += amount
         user.xp += 10
+        promo? user.promoexp += promoAmount :
         user.dailyquests = []
         user.markModified('dailystats')
 
@@ -203,8 +205,8 @@ cmd('daily', async (ctx, user) => {
         }
 
         return ctx.reply(user, {
-            description: `you recieved daily **${amount}** ${ctx.symbols.tomato} 
-                You have now **${Math.round(user.exp)}** ${ctx.symbols.tomato}`,
+            description: `you received daily **${amount}** ${ctx.symbols.tomato} ${promo? `and **${promoAmount}** ${promo.currency}`: ""}
+                You now have **${Math.round(user.exp)}** ${ctx.symbols.tomato} ${promo? `and **${user.promoexp}** ${promo.currency}`: ""}`,
             color: colors.green,
             fields
         })

--- a/modules/audit.js
+++ b/modules/audit.js
@@ -10,7 +10,7 @@ const {tryGetUserID}     = require('../utils/tools')
 
 
 const clean_audits = async (ctx, now) => {
-    const auditcleanup = asdate.subtract(new Date(), 21, 'days')
+    const auditcleanup = asdate.subtract(new Date(), 14, 'days')
     await Audit.deleteMany({time: {$lt: auditcleanup}})
     await AuditAucSell.deleteMany({time: {$lt: auditcleanup}})
 }

--- a/modules/secondarycheck.js
+++ b/modules/secondarycheck.js
@@ -8,8 +8,7 @@ const check_achievements = async (ctx, user, action, channelID) => {
     if(complete) {
         const reward = complete.resolve(ctx, user)
         user.achievements.push(complete.id)
-        await User.findOneAndUpdate({discord_id: user.discord_id}, 
-            {$push: { achievements: complete.id }})
+        await user.save()
 
         return ctx.send(channelID || ctx.msg.channel.id, {
             color: colors.blue,

--- a/staticdata/help.json
+++ b/staticdata/help.json
@@ -787,7 +787,7 @@
             },
             {
                 "title": "Tagging Guidelines",
-                "description": "We are looking for useful tags, not tags based on opinions. \nTag types we are looking for:\n- Character name(s) of pictured\n- Fandom name(s) pictured\n- Key descriptions: `Animal_ears, cat_ears, fox_girl, maid`\n- Word Separation with \\_: Kanna`_`Kamui\n\nTag types we are NOT looking for:\n- Cute X: `Cute girls, cute girl, cute boys, cute boy`\n- Best X: `Best Girl, Best Boy, Best Character etc.`\n- Worst X: `Same as above, replace best with worst`\n- No Word Separation: kannakamui"
+                "description": "__FAILURE TO FOLLOW THE BELOW CAN RESULT IN YOU BEING BANNED FROM TAGGING__\nWe are looking for useful tags, not tags based on opinions. \nTag types we are looking for:\n- Character name(s) of pictured\n- Fandom name(s) pictured\n- Key descriptions: `Animal_ears, cat_ears, fox_girl, maid`\n- Word Separation with \\_: Kanna`_`Kamui\n\nTag types we are NOT looking for:\n- Cute X: `Cute girls, cute girl, cute boys, cute boy`\n- Best X: `Best Girl, Best Boy, Best Character etc.`\n- Worst X: `Same as above, replace best with worst`\n- No Word Separation: kannakamui"
             }
 
         ]

--- a/staticdata/help.json
+++ b/staticdata/help.json
@@ -102,6 +102,10 @@
                 "description": "You can also spend your tomatoes by accepting trade requests from other users (`->help sell`) and selling cards on auction (`->help auc`)"
             },
             {
+                "title": "Promo Currency",
+                "description": "Promo currency is gotten by doing daily and claiming cards"
+            },
+            {
                 "title": "->bal",
                 "description": "Get your balance"
             }
@@ -757,6 +761,10 @@
         "title": "About tagging",
         "description": "You can tag cards with #tags to help you and the playerbase better find cards. Adding a tag already on a card upvotes the tag",
         "fields": [ 
+            {
+                "title": "IMPORTANT INFORMATION",
+                "description": "Tags are a global item, meaning everyone can see your tags. This is why we have tag rules. Read below for tag rules, if you have not run `->help tag`, do that command to see the rules. Or do `->rules`."
+            },
             {
                 "title": "->tag [card] #tag",
                 "description": "Upvote or Add a tag to a card"


### PR DESCRIPTION
Added promo claim to audit find
Daily now gives promo XP if promo is running, receipt now shows new promo gained if claim is not promo and promo is running
Audit collection now clears in 2 weeks instead of 3