### PR TITLE
Sudo remove, quest changes, achievement add, rating in diff

### DIFF
--- a/commands/admin.js
+++ b/commands/admin.js
@@ -17,6 +17,7 @@ const {
 const {
     formatName,
     addUserCard,
+    removeUserCard,
     withGlobalCards,
     bestMatch,
 } = require('../modules/card')
@@ -116,6 +117,22 @@ pcmd(['admin', 'mod'], ['sudo', 'add', 'card'], withGlobalCards(async (ctx, user
     await target.save()
 
     return ctx.reply(user, `added ${formatName(card)} to **${target.username}**`)
+}))
+
+pcmd(['admin', 'mod'], ['sudo', 'remove', 'card'], withGlobalCards(async (ctx, user, cards, parsedargs, args) => {
+    if(!parsedargs.ids[0])
+        throw new Error(`please specify user ID`)
+
+    var target = await fetchOnly(parsedargs.ids[0])
+
+    if(!target)
+        throw new Error(`cannot find user with that ID`)
+
+    const card = bestMatch(cards)
+    removeUserCard(target, card.id)
+    await target.save()
+
+    return ctx.reply(user, `removed ${formatName(card)} from **${target.username}**`)
 }))
 
 pcmd(['admin'], ['sudo', 'stress'], async (ctx, user, ...args) => {

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -302,6 +302,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args)
                       Tomatoes: **${findUser.exp}${ctx.symbols.tomato}** 
                       Vials: **${findUser.vials}${ctx.symbols.vial}**
                       Promo Currency: **${findUser.promoexp}**
+                      Join Date: **${findUser.joined}**
                       Last Daily: **${findUser.lastdaily}**
                       Unique Cards: **${findUser.cards.length}**
                       Completed Collections: **${findUser.completedcols? findUser.completedcols.length: 0}**

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -129,7 +129,7 @@ pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
 
     const list = await Transaction.find(search).sort({ time: -1 })
 
-    if(list.length == 0)
+    if(!list)
         return ctx.reply(user, `there are no transactions found.`, 'red')
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
@@ -154,7 +154,7 @@ pcmd(['admin', 'auditor'], ['audit', 'guild'], async (ctx, user, ...args) => {
 
     let list = await Transaction.find(search).sort({ time :-1})
 
-    if(list.length == 0)
+    if(!list)
         return ctx.reply(user, `there are no transactions found.`, 'red')
 
 
@@ -285,7 +285,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args)
 
     const findUser = await User.findOne({discord_id: arg.id})
 
-    if (findUser.length == 0)
+    if (!findUser)
         return ctx.reply(user, 'no user found with that ID', 'red')
 
     let effects = findUser.effects.map(x => x.id)
@@ -322,7 +322,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'trans'], withGlobalCards(async (ct
     }).sort({ time: -1 }).limit(100)
 
     if(list.length == 0)
-        return ctx.reply(user, `matched ${cards.length} cards and 0 transactions`)
+        return ctx.reply(user, `No matches found`, 'red')
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: paginate_guildtrslist(ctx, user, list),

--- a/commands/card.js
+++ b/commands/card.js
@@ -224,7 +224,7 @@ cmd('sell', withCards(async (ctx, user, cards, parsedargs) => {
         return ctx.qhelp(ctx, user, 'sell')
 
     if(user.ban && user.ban.embargo)
-        return ctx.reply(user, `you are not allowed to list cards at auction.
+        return ctx.reply(user, `you are not allowed to sell cards.
                                 Your dealings were found to be in violation of our community rules.
                                 You can inquire further on our [Bot Discord](${ctx.cafe})`, 'red')
 

--- a/commands/hero.js
+++ b/commands/hero.js
@@ -39,6 +39,7 @@ const Anilist = new anilist();
 
 cmd(['hero'], withUserEffects(async (ctx, user, effects, ...args) => {
     const now = new Date()
+    await user.save()
     effects = effects.filter(x => !x.expires || x.expires > now)
     if(!user.hero)
         return ctx.reply(user, `you don't have a hero yet. To get one use \`->hero get [hero name]\``, 'red')
@@ -165,6 +166,7 @@ cmd(['effects'], ['hero', 'effects'], withUserEffects(async (ctx, user, effects,
 
 cmd(['slots'], ['hero', 'slots'], withUserEffects(async (ctx, user, effects, ...args) => {
     const now = new Date()
+    await user.save()
     effects = effects.filter(x => !x.expires || x.expires > now)
     const hero = await get_hero(ctx, user.hero)
     const pages = ctx.pgn.getPages(effects.filter(x => x.passive)

--- a/commands/tag.js
+++ b/commands/tag.js
@@ -216,8 +216,19 @@ pcmd(['admin', 'mod', 'tagmod'], ['tag', 'mod', 'info'],
 
 pcmd(['admin', 'mod', 'tagmod'], ['tag', 'list'], async (ctx, user) => {
     const tags = await fetchTagNames(ctx);
+    const pages = []
+
+    tags.map((t, i) => {
+        if (i % 100 == 0) pages.push("")
+        if ((i + 1) % 5 == 0) {
+            pages[Math.floor(i/100)] += `**${t}**\n`
+        } else {
+            pages[Math.floor(i/100)] += `**${t}**  | `
+        }
+    })
+
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-        pages: ctx.pgn.getPages(tags),
+        pages,
         buttons: ['back', 'forward'],
         embed: {
             author: { name: `List of all tag names: ${tags.length} results` },

--- a/commands/user.js
+++ b/commands/user.js
@@ -329,7 +329,7 @@ cmd('diff', async (ctx, user, ...args) => {
         return ctx.reply(user, `no different cards found`, 'red')
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-        pages: ctx.pgn.getPages(diff.map(x => `${formatName(x)} ${x.amount > 1? `(x${x.amount})`: ''}`), 15),
+        pages: ctx.pgn.getPages(diff.map(x => `${formatName(x)} ${x.amount > 1? `(x${x.amount})`: ''} ${x.rating? `[${x.rating}/10]` : ''}`), 15),
         embed: { author: { name: `${user.username}, unique cards FROM ${otherUser.username} (${diff.length} results)` } }
     })
 })
@@ -364,7 +364,7 @@ cmd(['diff', 'reverse'], ['diff', 'rev'], async (ctx, user, ...args) => {
         return ctx.reply(user, `no different cards found`, 'red')
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-        pages: ctx.pgn.getPages(diff.map(x => `${formatName(x)} ${x.amount > 1? `(x${x.amount})`: ''}`), 15),
+        pages: ctx.pgn.getPages(diff.map(x => `${formatName(x)} ${x.amount > 1? `(x${x.amount})`: ''} ${x.rating? `[${x.rating}/10]` : ''}`), 15),
         embed: { author: { name: `${user.username}, unique cards FOR ${otherUser.username} (${diff.length} results)` } }
     })
 })

--- a/modules/effect.js
+++ b/modules/effect.js
@@ -25,10 +25,13 @@ const formatUserEffect = (ctx, user, x) => {
     return `\`${eff.id}\` **${eff.name}** ${lasts? `(${lasts})` : ''}`
 }
 
-const mapUserEffects = (ctx, user) => user.effects.map(x => Object.assign({}, 
-    ctx.items.find(y => y.effectid === x.id), 
-    ctx.effects.find(y => y.id === x.id), 
-    x))
+const mapUserEffects = (ctx, user) => {
+    user.effects.map(x => check_effect(ctx, user, x.id))
+    return user.effects.map(x => Object.assign({},
+        ctx.items.find(y => y.effectid === x.id),
+        ctx.effects.find(y => y.id === x.id),
+        x))
+}
 
 const withUserEffects = (callback) => (ctx, user, ...args) => {
     if(!user.hero)

--- a/modules/tag.js
+++ b/modules/tag.js
@@ -9,7 +9,7 @@ const fetchTaggedCards = async (tags) => {
 const fetchTagNames = async (ctx) => {
     const res = await Tag.find()
     let names = []
-    res.map(t => names.indexOf(t.name) == -1 && t.status != 'banned'? names.push(t.name): t)
+    res.map(t => names.indexOf(t.name) == -1 && t.status != 'banned' && t.status != 'removed'? names.push(t.name): t)
     return names.sort()
 }
 

--- a/modules/transaction.js
+++ b/modules/transaction.js
@@ -88,7 +88,7 @@ const confirm_trs = async (ctx, user, trs_id) => {
         await completed(ctx, to_user, fullCard)
         to_user.exp -= transaction.price
 
-        const auditCheck = await Auction.findOne({ author: transaction.to_id, card: card.id})
+        const auditCheck = await Auction.findOne({ author: transaction.to_id, card: card.id, bids: {$gte: 0}})
         if (auditCheck) {
             const auditDB = await new Audit()
             const last_audit = (await Audit.find().sort({ _id: -1 }))[0]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amusementclub2.0",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Next version of Amusement Club discord gacha",
   "main": "index.js",
   "scripts": {

--- a/staticdata/achievements.js
+++ b/staticdata/achievements.js
@@ -119,6 +119,21 @@ module.exports = [
             user.exp += 500
             return `**500** ${ctx.symbols.tomato}`
         }
+    }, {
+        id: 'firsteffect',
+        name: `Now that's effective!`,
+        desc: 'Create your first effect card',
+        actions: ['inv'],
+        check: (ctx, user) => {
+            const effect = user.effects[0]
+            if (effect)
+                return true
+            return false
+        },
+        resolve: (ctx, user) => {
+            user.exp += 500
+            return `**500** ${ctx.symbols.tomato}`
+        }
     }
 
 

--- a/staticdata/items.json
+++ b/staticdata/items.json
@@ -141,23 +141,23 @@
         "price": 1500,
         "type": "blueprint",
         "desc": "get quests",
-        "fulldesc": "When built and upgraded, gives players up to **2** daily quests and allows to purchase quest lines",
+        "fulldesc": "When built and upgraded, gives players up to **2** extra daily quests and allows to purchase quest lines",
         "levels": [
             {
                 "price": 1000,
                 "level": 2,
                 "maintenance": 50,
-                "desc": "Adds 2 quests when users run daily in this guild"
+                "desc": "Adds 1 extra quest when users run daily in this guild"
             }, {
                 "price": 2000,
                 "level": 5,
                 "maintenance": 200,
-                "desc": "Adds 3 quests when users run daily in this guild"
+                "desc": "Adds 2 extra quests when users run daily in this guild"
             }, {
                 "price": 20000,
                 "level": 27,
                 "maintenance": 1000,
-                "desc": "Allows to purchase quest lines"
+                "desc": "Allows to purchase quest lines (Not Implemented Currently)"
             }
         ]
     }, {

--- a/staticdata/quests.js
+++ b/staticdata/quests.js
@@ -32,22 +32,22 @@ module.exports = {
             actions: ['auc', 'auction'],
             check: (ctx, user) => user.dailystats.bids >= 2,
             resolve: (ctx, user) => {
-                user.exp += 1000
+                user.exp += 900
                 user.xp += 2
             },
-            reward: (ctx) => `**1000** ${ctx.symbols.tomato} and **2** xp`
+            reward: (ctx) => `**900** ${ctx.symbols.tomato} and **2** xp`
         }, {
             id: 'bid5',
-            name: 'Bid on 5 auctions today',
+            name: 'Bid on 4 auctions today',
             desc: '',
             tier: 2,
             actions: ['auc', 'auction'],
-            check: (ctx, user) => user.dailystats.bids >= 5,
+            check: (ctx, user) => user.dailystats.bids >= 4,
             resolve: (ctx, user) => {
-                user.exp += 2500
+                user.exp += 1800
                 user.xp += 5
             },
-            reward: (ctx) => `**2500** ${ctx.symbols.tomato} and **5** xp`
+            reward: (ctx) => `**1800** ${ctx.symbols.tomato} and **5** xp`
         }, {
             id: 'forge1',
             name: 'Forge 1-star card',
@@ -57,10 +57,10 @@ module.exports = {
             actions: ['forge'],
             check: (ctx, user) => user.dailystats.forge1 >= 1,
             resolve: (ctx, user) => {
-                user.exp += 700
+                user.exp += 300
                 user.xp += 1
             },
-            reward: (ctx) => `**700** ${ctx.symbols.tomato} and **1** xp`
+            reward: (ctx) => `**300** ${ctx.symbols.tomato} and **1** xp`
         }, {
             id: 'forge2',
             name: 'Forge 2-star card',
@@ -70,10 +70,11 @@ module.exports = {
             actions: ['forge'],
             check: (ctx, user) => user.dailystats.forge2 >= 1,
             resolve: (ctx, user) => {
-                user.exp += 1200
+                user.exp += 400
+                user.vials += 20
                 user.xp += 2
             },
-            reward: (ctx) => `**1200** ${ctx.symbols.tomato} and **2** xp`
+            reward: (ctx) => `**400** ${ctx.symbols.tomato}, **20** ${ctx.symbols.vial} and **2** xp`
         }, {
             id: 'forge3',
             name: 'Forge 3-star card',
@@ -83,10 +84,11 @@ module.exports = {
             actions: ['forge'],
             check: (ctx, user) => user.dailystats.forge3 >= 1,
             resolve: (ctx, user) => {
+                user.exp += 400
                 user.vials += 40
                 user.xp += 4
             },
-            reward: (ctx) => `**40** ${ctx.symbols.vial} and **4** xp`
+            reward: (ctx) => `**400** ${ctx.symbols.tomato}, **40** ${ctx.symbols.vial} and **4** xp`
         }, {
             id: 'tag2',
             name: 'Tag 2 cards',
@@ -95,10 +97,10 @@ module.exports = {
             actions: ['tag'],
             check: (ctx, user) => user.dailystats.tags >= 2,
             resolve: (ctx, user) => {
-                user.exp += 600
+                user.exp += 400
                 user.xp += 2
             },
-            reward: (ctx) => `**600** ${ctx.symbols.tomato} and **2** xp`
+            reward: (ctx) => `**400** ${ctx.symbols.tomato} and **2** xp`
         }, {
             id: 'tag4',
             name: 'Tag 4 cards',
@@ -107,10 +109,10 @@ module.exports = {
             actions: ['tag'],
             check: (ctx, user) => user.dailystats.tags >= 4,
             resolve: (ctx, user) => {
-                user.exp += 1500
+                user.exp += 800
                 user.xp += 4
             },
-            reward: (ctx) => `**1500** ${ctx.symbols.tomato} and **4** xp`
+            reward: (ctx) => `**800** ${ctx.symbols.tomato} and **4** xp`
         }, {
             id: 'liq2',
             name: 'Liquify 2 cards',
@@ -124,6 +126,19 @@ module.exports = {
                 user.xp += 3
             },
             reward: (ctx) => `**55** ${ctx.symbols.vial} and **3** xp`
+        }, {
+            id: 'draw2',
+            name: 'Draw 2 cards',
+            desc: '',
+            tier: 2,
+            building: 'smithhub2',
+            actions: ['draw'],
+            check: (ctx, user) => user.dailystats.draw >= 2,
+            resolve: (ctx, user) => {
+                user.exp += 400
+                user.xp += 3
+            },
+            reward: (ctx) => `**400** ${ctx.symbols.tomato} and **3** xp`
         },
     ],
 


### PR DESCRIPTION
Added a new quest and achievement

Fixed wording on tavern, as 1 quest is default

Changed tag list to show 100 per page and it properly removes the removed tags from displaying

Reduced rewards on a lot of quests and tweaked the rewards as well, this is not set, we will see how these changes affect things.