### PR TITLE
Audit additions and fixes

### DIFF
--- a/commands/audit.js
+++ b/commands/audit.js
@@ -1,7 +1,6 @@
 const {pcmd}                    = require('../utils/cmd')
 const {evalCard}                = require('../modules/eval')
 const {fetchOnly}               = require('../modules/user')
-const {fetchUserTags}           = require("../modules/tag");
 const colors                    = require('../utils/colors')
 const msToTime                  = require('pretty-ms')
 const {paginate_trslist, ch_map} = require('../modules/transaction')

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -1,6 +1,7 @@
 const {pcmd}                    = require('../utils/cmd')
 const {evalCard}                = require('../modules/eval')
 const {fetchOnly}               = require('../modules/user')
+const {fetchUserTags}           = require("../modules/tag");
 const colors                    = require('../utils/colors')
 const msToTime                  = require('pretty-ms')
 const {paginate_trslist, ch_map} = require('../modules/transaction')
@@ -8,8 +9,6 @@ const dateFormat                = require(`dateformat`)
 
 const {
     formatName,
-    mapUserCards,
-    parseArgs,
     withGlobalCards
 }   = require('../modules/card')
 
@@ -141,6 +140,34 @@ pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
         }
     })
 })
+
+pcmd(['admin', 'auditor'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx, user, cards, arg) => {
+    if (ctx.msg.channel.id != ctx.audit.channel)
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+
+    if (!arg.ids)
+        return ctx.reply(user, `please submit a valid user ID`, 'red')
+
+    const auditedUser = await fetchOnly(arg.ids)
+    const userTags = await fetchUserTags(auditedUser)
+    const cardIDs = cards.map(x => x.id)
+    const tags = userTags.filter(x => cardIDs.includes(x.card))
+
+    if(tags.length === 0)
+        return ctx.reply(user, `cannot find tags for matching cards (${cards.length} cards matched)`)
+
+    return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
+        pages: ctx.pgn.getPages(tags.map(x => {
+            const card = ctx.cards[x.card]
+            return `\`${ctx.symbols.accept}${x.upvotes.length} ${ctx.symbols.decline}${x.downvotes.length}\` **#${x.name}** - ${formatName(card)}`
+        }, 10)),
+        switchPage: (data) => data.embed.description = `**${user.username}**, tags that ${auditedUser.username} created:\n\n${data.pages[data.pagenum]}`,
+        buttons: ['back', 'forward'],
+        embed: {
+            color: colors.blue,
+        }
+    })
+}))
 
 pcmd(['admin', 'auditor'], ['audit', 'guild'], async (ctx, user, ...args) => {
     if (ctx.msg.channel.id != ctx.audit.channel)
@@ -372,17 +399,15 @@ pcmd(['admin', 'auditor'], ['audit', 'closed'], async (ctx, user, arg) => {
     })
 })
 
-pcmd(['admin', 'auditor'], ['audit', 'list'], ['audit', 'li'], ['audit', 'cards'], ['audit', 'ls'], async (ctx, user, ...args) => {
+pcmd(['admin', 'auditor'], ['audit', 'list'], ['audit', 'li'], ['audit', 'cards'], ['audit', 'ls'], withGlobalCards(async (ctx, user, cards, arg) => {
     if (ctx.msg.channel.id != ctx.audit.channel)
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
-    
-    let arg = parseArgs(ctx, args)
+
     if (!arg.ids)
         return ctx.reply(user, `please submit a valid user ID`, 'red')
 
     const findUser = await User.findOne({discord_id: arg.ids})
     const now = new Date()
-    const cards = mapUserCards(ctx, findUser).sort(arg.sort)
     const cardstr = cards.map(c => {
         const isnew = c.obtained > (findUser.lastdaily || now)
         return (isnew? '**[new]** ' : '') + formatName(c) + (c.amount > 1? ` (x${c.amount}) ` : ' ') + (c.rating? `[${c.rating}/10]` : '')
@@ -392,4 +417,4 @@ pcmd(['admin', 'auditor'], ['audit', 'list'], ['audit', 'li'], ['audit', 'cards'
         pages: ctx.pgn.getPages(cardstr, 15),
         embed: { author: { name: `${user.username}, here are ${findUser.username}'s cards (${cards.length} results)` } }
     })
-})
+}))

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -13,6 +13,7 @@ const {
 }   = require('../modules/card')
 
 const {
+    auditFetchUserTags,
     formatAucBidList,
     paginate_auditReports,
     paginate_guildtrslist,
@@ -141,7 +142,7 @@ pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
     })
 })
 
-pcmd(['admin', 'auditor'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx, user, cards, arg) => {
+pcmd(['admin', 'auditor', 'tagmod'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx, user, cards, arg) => {
     if (ctx.msg.channel.id != ctx.audit.channel)
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
@@ -149,7 +150,7 @@ pcmd(['admin', 'auditor'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx
         return ctx.reply(user, `please submit a valid user ID`, 'red')
 
     const auditedUser = await fetchOnly(arg.ids)
-    const userTags = await fetchUserTags(auditedUser)
+    const userTags = await auditFetchUserTags(auditedUser)
     const cardIDs = cards.map(x => x.id)
     const tags = userTags.filter(x => cardIDs.includes(x.card))
 
@@ -159,10 +160,10 @@ pcmd(['admin', 'auditor'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(tags.map(x => {
             const card = ctx.cards[x.card]
-            return `\`${ctx.symbols.accept}${x.upvotes.length} ${ctx.symbols.decline}${x.downvotes.length}\` **#${x.name}** - ${formatName(card)}`
+            return `\`${ctx.symbols.accept}${x.upvotes.length} ${ctx.symbols.decline}${x.downvotes.length}\` **#${x.name}** ${x.status!='clear'? `(${x.status})`: ''} - ${formatName(card)}`
         }, 10)),
         switchPage: (data) => data.embed.description = `**${user.username}**, tags that ${auditedUser.username} created:\n\n${data.pages[data.pagenum]}`,
-        buttons: ['back', 'forward'],
+        buttons: ['first', 'back', 'forward', 'last'],
         embed: {
             color: colors.blue,
         }

--- a/commands/smith.js
+++ b/commands/smith.js
@@ -48,7 +48,7 @@ cmd(['forge'], withMultiQuery(async (ctx, user, cards, parsedargs) => {
 
     if(!card1 || !card2)
         return ctx.reply(user, `not enough cards found matching this query.
-            You can specify one query that can get 2+ cards, or 2 queries using \`,\` as separator`, 'red')
+            You can specify one query that can get 2+ unique cards, or 2 queries using \`,\` as separator`, 'red')
 
     if(card1.level != card2.level)
         return ctx.reply(user, `you can forge only cards of the same star count`, 'red')

--- a/commands/tag.js
+++ b/commands/tag.js
@@ -246,8 +246,8 @@ pcmd(['admin', 'mod', 'tagmod'], ['tag', 'mod', 'info'],
 
 }))
 
-pcmd(['admin', 'mod', 'tagmod'], ['tag', 'list'], async (ctx, user) => {
-    const tags = await fetchTagNames(ctx);
+pcmd(['admin', 'mod', 'tagmod'], ['tag', 'list'], async (ctx, user, arg) => {
+    const tags = await fetchTagNames(ctx, arg);
     const pages = []
 
     tags.map((t, i) => {
@@ -261,7 +261,7 @@ pcmd(['admin', 'mod', 'tagmod'], ['tag', 'list'], async (ctx, user) => {
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages,
-        buttons: ['back', 'forward'],
+        buttons: ['first', 'back', 'forward', 'last'],
         embed: {
             author: { name: `List of all tag names: ${tags.length} results` },
             color: colors.blue,

--- a/commands/tag.js
+++ b/commands/tag.js
@@ -263,7 +263,7 @@ pcmd(['admin', 'mod', 'tagmod'], ['tag', 'list'], async (ctx, user, arg) => {
         pages,
         buttons: ['first', 'back', 'forward', 'last'],
         embed: {
-            author: { name: `List of all tag names: ${tags.length} results` },
+            author: { name: `List of ${arg? `tags starting with "${arg}"`: 'all tag names' }: ${tags.length} results` },
             color: colors.blue,
         }
     })

--- a/modules/audit.js
+++ b/modules/audit.js
@@ -128,7 +128,7 @@ const parseAuditArgs = (ctx, args) => {
                 break
             default:
                 const tryid = tryGetUserID(x)
-                if(tryid && !a.id) a.id = x
+                if(tryid && !a.id) a.id = tryid
                 else a.extraArgs.push(x)
         }
     })

--- a/modules/audit.js
+++ b/modules/audit.js
@@ -3,6 +3,7 @@ const AuditAucSell       = require('../collections/auditAucSell')
 const asdate             = require('add-subtract-date')
 const dateFormat         = require(`dateformat`)
 const msToTime           = require('pretty-ms')
+const Tag                = require("../collections/tag");
 const {ch_map} = require('./transaction')
 const {formatName}       = require('./card')
 const {tryGetUserID}     = require('../utils/tools')
@@ -106,6 +107,11 @@ const formatCompletedList = (ctx, user, audit) => {
     return resp;
 }
 
+const auditFetchUserTags = async (user) => {
+    const res = await Tag.find({ author: user.discord_id })
+    return res.reverse()
+}
+
 const parseAuditArgs = (ctx, args) => {
     const a = {
         id: '',
@@ -138,6 +144,7 @@ const parseAuditArgs = (ctx, args) => {
 
 
 module.exports = {
+    auditFetchUserTags,
     paginate_auditReports,
     paginate_guildtrslist,
     paginate_closedAudits,

--- a/modules/tag.js
+++ b/modules/tag.js
@@ -8,7 +8,7 @@ const fetchTaggedCards = async (tags) => {
 
 const fetchTagNames = async (ctx, start) => {
     let res
-    if (letter) {
+    if (start) {
         res = await Tag.find({name: {$in: new RegExp('^' + start)}})
     } else {
         res = await Tag.find()

--- a/modules/tag.js
+++ b/modules/tag.js
@@ -9,7 +9,7 @@ const fetchTaggedCards = async (tags) => {
 const fetchTagNames = async (ctx) => {
     const res = await Tag.find()
     let names = []
-    res.map(t => names.indexOf(t.name) == -1 && t.status != 'banned' && t.status != 'removed'? names.push(t.name): t)
+    res.map(t => names.indexOf(t.name) == -1 && check_tag(t)? names.push(t.name): t)
     return names.sort()
 }
 

--- a/modules/tag.js
+++ b/modules/tag.js
@@ -6,8 +6,14 @@ const fetchTaggedCards = async (tags) => {
     return res.filter(x => check_tag(x)).map(x => x.card)
 }
 
-const fetchTagNames = async (ctx) => {
-    const res = await Tag.find()
+const fetchTagNames = async (ctx, start) => {
+    let res
+    if (letter) {
+        res = await Tag.find({name: {$in: new RegExp('^' + start)}})
+    } else {
+        res = await Tag.find()
+    }
+
     let names = []
     res.map(t => names.indexOf(t.name) == -1 && check_tag(t)? names.push(t.name): t)
     return names.sort()

--- a/modules/transaction.js
+++ b/modules/transaction.js
@@ -88,7 +88,7 @@ const confirm_trs = async (ctx, user, trs_id) => {
         await completed(ctx, to_user, fullCard)
         to_user.exp -= transaction.price
 
-        const auditCheck = await Auction.findOne({ author: transaction.to_id, card: card.id, bids: {$gte: 0}})
+        const auditCheck = await Auction.findOne({ author: transaction.to_id, card: card.id,  "bids.0": { $exists: true }})
         if (auditCheck) {
             const auditDB = await new Audit()
             const last_audit = (await Audit.find().sort({ _id: -1 }))[0]

--- a/staticdata/achievements.js
+++ b/staticdata/achievements.js
@@ -40,8 +40,8 @@ module.exports = [
         }
     }, {
         id: 'allcards',
-        name: 'Did I win?',
-        desc: 'Collect All Cards',
+        name: 'Sketchy Collector!',
+        desc: 'Collect All Cards, the Sachi way!',
         actions: ['cl', 'claim', 'cards', 'ls'],
         check: (ctx, user) => user.cards.filter(x => ctx.cards[x.id] && !ctx.cards[x.id].excluded).length 
             >= ctx.cards.filter(x => !x.excluded).length,

--- a/staticdata/help.json
+++ b/staticdata/help.json
@@ -11,7 +11,7 @@
             },
             {
                 "title": "Card Management",
-                "description": "->help claim\n->help summon\n->help cards\n->help fav\n->help tag\n->help draw\n->help liq\n->help info\n->help query",
+                "description": "->help claim\n->help summon\n->help cards\n->help fav\n->help tag\n->help draw\n->help liq\n->help forge\n->help info\n->help query",
                 "inline": true
             },
             {

--- a/staticdata/help.json
+++ b/staticdata/help.json
@@ -774,6 +774,10 @@
                 "description": "Upvote or Add a tag to a card"
             },
             {
+                "title": "->tags created",
+                "description": "List all tags you have created"
+            },
+            {
                 "title": "->tag down [card] #some_tag_here",
                 "description": "Downvote a tag on a card"
             }, 


### PR DESCRIPTION
Added the ability for searching by tag start with tag list. Allowing tagmods to search by specific letters, or word starts. Also added first and last buttons to the mix, no more moving by single pages through all of the tags.

Added tagmods to audit user tags, and changed the fetch tag function to include banned/removed/downvoted tags for more thorough auditing

Made audit user tags to find more tags by specific users instead of attempting to find via list

Fixed tag list returning tags hidden by downvote by using an already implemented function.

audit list now accepts queries, and I fixed my stupidity on auditargs with name mentions

Mention unique in forging error as I saw someone attempt to forge the same card with itself multiple times.

Added tags created to the help

Honoring Sachi/Vivi/Eli via her achievement

Fixed report 3 not functioning because I don't know how to Mongo.