### PR TITLE
New features(see description)

### DIFF
--- a/commands/auction.js
+++ b/commands/auction.js
@@ -36,7 +36,8 @@ cmd('auc', withGlobalCards(async (ctx, user, cards, parsedargs) => {
 
     if(parsedargs.diff)
         list = list.filter(x => !user.cards.some(y => x.card === y.id))
-    else if(parsedargs.bid === 1) 
+
+    if(parsedargs.bid === 1)
         list = list.filter(x => x.lastbidder && x.lastbidder === user.discord_id)
     else if(parsedargs.bid === 2) 
         list = list.filter(x => !x.lastbidder || x.lastbidder != user.discord_id)

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -30,7 +30,7 @@ const {
 
 
 pcmd(['admin', 'auditor'], ['fraud', 'report'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
 
@@ -42,7 +42,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report'], async (ctx, user, ...args) => {
 })
 
 pcmd(['admin', 'auditor'], ['fraud', 'report', '1'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     let overSell = await AuditAucSell.find({sold: {$gt:5}}).sort({sold: -1, unsold: 1})
@@ -58,7 +58,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '1'], async (ctx, user, ...args) 
 })
 
 pcmd(['admin', 'auditor'], ['fraud', 'report', '2'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     let overPrice = (await Audit.find({ audited: false, report_type: 2 }).sort({price_over : -1}))
@@ -74,7 +74,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '2'], async (ctx, user, ...args) 
 })
 
 pcmd(['admin', 'auditor'], ['fraud', 'report', '3'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     let buybacks = await Audit.find({audited: false, report_type: 3}).sort({price: -1})
@@ -90,14 +90,14 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '3'], async (ctx, user, ...args) 
 })
 
 pcmd(['admin', 'auditor'], ['audit'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     return ctx.reply(user, "Current audit options are: auction, guild, trans, user, warn, find user, find trans, confirm")
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let arg = parseAuditArgs(ctx, args)
 
@@ -142,7 +142,7 @@ pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
 })
 
 pcmd(['admin', 'mod', 'auditor', 'tagmod'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx, user, cards, arg) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     if (!arg.ids)
@@ -170,7 +170,7 @@ pcmd(['admin', 'mod', 'auditor', 'tagmod'], ['audit', 'user', 'tags'], withGloba
 }))
 
 pcmd(['admin', 'auditor'], ['audit', 'guild'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let arg = parseAuditArgs(ctx, args)
     let search
@@ -196,7 +196,7 @@ pcmd(['admin', 'auditor'], ['audit', 'guild'], async (ctx, user, ...args) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'trans'], async (ctx, user, ...arg) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let trans = await Transaction.findOne({id: arg[0]})
 
@@ -230,7 +230,7 @@ pcmd(['admin', 'auditor'], ['audit', 'trans'], async (ctx, user, ...arg) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'warn'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let arg = parseAuditArgs(ctx, args)
     let warnedUser = await fetchOnly(arg.id)
@@ -254,7 +254,7 @@ pcmd(['admin', 'auditor'], ['audit', 'warn'], async (ctx, user, ...args) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'auc'], ['audit', 'auction'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     const auc = await Auction.findOne({ id: args[0] })
 
@@ -304,7 +304,7 @@ pcmd(['admin', 'auditor'], ['audit', 'auc'], ['audit', 'auction'], async (ctx, u
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
     let arg = parseAuditArgs(ctx, args)
     if (!arg.id)
@@ -342,7 +342,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args)
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'find', 'trans'], withGlobalCards(async (ctx, user, cards, ...args) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     const list = await Transaction.find({
@@ -363,7 +363,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'trans'], withGlobalCards(async (ct
 }))
 
 pcmd(['admin', 'auditor'], ['audit', 'complete'], ['audit', 'confirm'], async (ctx, user, arg) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     if (!arg)
@@ -381,7 +381,7 @@ pcmd(['admin', 'auditor'], ['audit', 'complete'], ['audit', 'confirm'], async (c
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'closed'], async (ctx, user, arg) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'this command can only be run in an audit channel.', 'red')
 
     const closedAudits = await Audit.find({audited: true}).sort({ _id: -1})
@@ -400,7 +400,7 @@ pcmd(['admin', 'auditor'], ['audit', 'closed'], async (ctx, user, arg) => {
 })
 
 pcmd(['admin', 'auditor'], ['audit', 'list'], ['audit', 'li'], ['audit', 'cards'], ['audit', 'ls'], withGlobalCards(async (ctx, user, cards, arg) => {
-    if (ctx.msg.channel.id != ctx.audit.channel)
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
     if (!arg.ids)

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -141,7 +141,7 @@ pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
     })
 })
 
-pcmd(['admin', 'mod', 'auditor', 'tagmod'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx, user, cards, arg) => {
+pcmd(['admin', 'mod', 'auditor', 'tagmod'], ['audit', 'user', 'tags'], withGlobalCards(async (ctx, user, cards, arg, fullArgs) => {
     if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
@@ -149,7 +149,8 @@ pcmd(['admin', 'mod', 'auditor', 'tagmod'], ['audit', 'user', 'tags'], withGloba
         return ctx.reply(user, `please submit a valid user ID`, 'red')
 
     const auditedUser = await fetchOnly(arg.ids)
-    const userTags = await auditFetchUserTags(auditedUser)
+    const auditArgs = parseAuditArgs(ctx, fullArgs)
+    const userTags = await auditFetchUserTags(auditedUser, auditArgs)
     const cardIDs = cards.map(x => x.id)
     const tags = userTags.filter(x => cardIDs.includes(x.card))
 

--- a/commands/card.js
+++ b/commands/card.js
@@ -338,7 +338,11 @@ cmd(['eval', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
     let vials = 0
     cards.map(card => {
         const eval = evalCardFast(ctx, card)
-        price += eval * card.amount
+        if(eval >= 0) {
+            price += Math.round(eval) * card.amount
+        } else {
+            price = NaN
+        }
         if(card.level < 4 && eval !== 0) {
             vials += getVialCostFast(ctx, card, eval) * card.amount
         }
@@ -359,15 +363,17 @@ cmd(['eval', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
 }))
 
 cmd(['eval', 'all', 'global'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
-    if(parsedargs.isEmpty())
-        return ctx.qhelp(ctx, user, 'eval')
 
     let price = 0
     let vials = 0
     cards.map(card => {
         const eval = evalCardFast(ctx, card)
-        price += eval
-        if(card.level < 4) {
+        if(eval >= 0) {
+            price += Math.round(eval)
+        } else {
+            price = NaN
+        }
+        if(card.level < 4 && eval !== 0) {
             vials += getVialCostFast(ctx, card, eval)
         }
     })

--- a/commands/card.js
+++ b/commands/card.js
@@ -3,6 +3,7 @@ const {fetchCardTags}       = require('../modules/tag')
 const colors                = require('../utils/colors')
 const msToTime              = require('pretty-ms')
 const dateFormat            = require(`dateformat`)
+const User                  = require('../collections/user')
 
 const _ = require('lodash')
 
@@ -242,7 +243,7 @@ cmd('sell', withCards(async (ctx, user, cards, parsedargs) => {
         return ctx.qhelp(ctx, user, 'sell')
 
     const id = parsedargs.ids[0]
-    const targetuser = id? await User.findOne({ discord_id: to_id }) : null
+    const targetuser = id? await User.findOne({ discord_id: id }) : null
     const err = await validate_trs(ctx, user, cards, id, targetuser)
     if(err) {
         return ctx.reply(user, err, 'red')
@@ -276,7 +277,7 @@ cmd(['sell', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
         return ctx.qhelp(ctx, user, 'sell')
 
     const id = parsedargs.ids[0]
-    const targetuser = id? await User.findOne({ discord_id: to_id }) : null
+    const targetuser = id? await User.findOne({ discord_id: id }) : null
     const err = await validate_trs(ctx, user, cards, id, targetuser)
     if(err) {
         return ctx.reply(user, err, 'red')

--- a/commands/card.js
+++ b/commands/card.js
@@ -339,7 +339,7 @@ cmd(['eval', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
     cards.map(card => {
         const eval = evalCardFast(ctx, card)
         price += eval * card.amount
-        if(card.level < 4) {
+        if(card.level < 4 && eval !== 0) {
             vials += getVialCostFast(ctx, card, eval) * card.amount
         }
     })

--- a/commands/card.js
+++ b/commands/card.js
@@ -333,16 +333,14 @@ cmd('eval', withGlobalCards(async (ctx, user, cards, parsedargs) => {
 }))
 
 cmd(['eval', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
-    if(parsedargs.isEmpty())
-        return ctx.qhelp(ctx, user, 'eval')
 
     let price = 0
     let vials = 0
     cards.map(card => {
         const eval = evalCardFast(ctx, card)
-        price += eval
+        price += eval * card.amount
         if(card.level < 4) {
-            vials += getVialCostFast(ctx, card, eval)
+            vials += getVialCostFast(ctx, card, eval) * card.amount
         }
     })
     

--- a/commands/meta.js
+++ b/commands/meta.js
@@ -45,10 +45,6 @@ cmd('info', ['card', 'info'], withGlobalCards(async (ctx, user, cards, parsedarg
     const usercard = user.cards.find(x => x.id === card.id)
     const embed = { color: colors.blue, fields: [] }
 
-    if(usercard) {
-        user.lastcard = card.id
-        await user.save()
-    }
 
     resp.push(formatName(card))
     resp.push(`Fandom: **${col.name}**`)
@@ -62,6 +58,9 @@ cmd('info', ['card', 'info'], withGlobalCards(async (ctx, user, cards, parsedarg
 
     if(card.added)
         resp.push(`Added: **${dateFormat(card.added, "yyyy-mm-dd")}** (${msToTime(new Date() - card.added, {compact: true})})`)
+
+    if (extrainfo.ownercount > 0)
+        resp.push(`Owner Count: **${extrainfo.ownercount}**`)
 
     resp.push(`ID: ${card.id}`)
     embed.description = resp.join('\n')

--- a/commands/tag.js
+++ b/commands/tag.js
@@ -257,7 +257,7 @@ pcmd(['admin', 'mod', 'tagmod'], ['tag', 'ban'],
 
     try {
         await ctx.direct(target, `your tag **#${tgTag}** for ${formatName(card)} has been banned by moderator.
-            Please make sure you add valid tags in the future. Learn more with \`->help tag\`
+            Please make sure you add valid tags in the future as tags are not personal. Learn more with \`->rules\`
             You have **${3 - target.ban.tags}** warning(s) remaining`, 'red')
     } catch {
         ctx.reply(user, `failed to send a warning to the user.`, 'red')

--- a/commands/tag.js
+++ b/commands/tag.js
@@ -75,9 +75,9 @@ cmd('tag', withTag(async (ctx, user, card, tag, tgTag, parsedargs) => {
             return ctx.reply(user, `tag can't be shorter than **2** characters`, 'red') 
     }
     let question = `Do you want to ${tag? 'upvote' : 'add'} tag **#${tgTag}** for ${formatName(card)}?`
-    console.log(parsedargs)
+
     if (parsedargs.firstTag)
-        question = question + `\n Before confirming, please note that tags are **global**, not personal!\nRead the \`->rules\` on how to tag!`
+        question += `\n Before confirming, please note that tags are **global**, not personal!\nRead the \`->rules\` on how to tag!`
 
     ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         check,

--- a/commands/tag.js
+++ b/commands/tag.js
@@ -1,7 +1,8 @@
 const {cmd, pcmd}       = require('../utils/cmd')
 const colors            = require('../utils/colors')
 const Tag               = require('../collections/tag')
-const {parseAuditArgs}  = require("../modules/audit");
+const {parseAuditArgs}  = require("../modules/audit")
+const dateFormat        = require('dateformat')
 
 const {
     fetchOnly,

--- a/modules/card.js
+++ b/modules/card.js
@@ -237,12 +237,13 @@ const withCards = (callback) => async (ctx, user, ...args) => {
     if(cards.length == 0)
         return ctx.reply(user, `no cards found matching \`${args.join(' ')}\``, 'red')
 
+    cards.sort(parsedargs.sort)
+
     if(!parsedargs.lastcard && cards.length > 0) {
-        user.lastcard = bestMatch(cards).id
+        user.lastcard = cards[0].id
         await user.save()
     }
 
-    cards.sort(parsedargs.sort)
     return callback(ctx, user, cards, parsedargs, args)
 }
 
@@ -280,6 +281,12 @@ const withGlobalCards = (callback) => async(ctx, user, ...args) => {
         return ctx.reply(user, `no cards found matching \`${args.join(' ')}\``, 'red')
 
     cards.sort(parsedargs.sort)
+
+    if(!parsedargs.lastcard && cards.length > 0) {
+        user.lastcard = cards[0].id
+        await user.save()
+    }
+
     return callback(ctx, user, cards, parsedargs, args)
 }
 

--- a/modules/eval.js
+++ b/modules/eval.js
@@ -113,8 +113,9 @@ const checkQueue = async (ctx) => {
 
 const getEval = (ctx, card, ownerCount, modifier = 1) => {
     const allUsers = userCount || ownerCount * 2
-    return Math.round(((ctx.eval.cardPrices[card.level] + (card.animated? 100 : 0))
+    let eval = Math.round(((ctx.eval.cardPrices[card.level] + (card.animated? 100 : 0))
         * limitPriceGrowth((allUsers * ctx.eval.evalUserRate) / ownerCount)) * modifier)
+    return eval === Infinity? 0: eval
 }
 
 const getQueueTime = () => evalQueue.length * queueTick

--- a/modules/tag.js
+++ b/modules/tag.js
@@ -87,6 +87,7 @@ const withTag = (callback, forceFind = true) => async(ctx, user, ...args) => {
         return ctx.reply(user, `tag #${tgTag} wasn't found for ${cardMod.formatName(card)}`, 'red')
 
     const priorTags = await Tag.findOne({author: user.discord_id, status: 'clear'})
+
     if (!priorTags)
         parsedargs.firstTag = true
 

--- a/modules/transaction.js
+++ b/modules/transaction.js
@@ -53,7 +53,7 @@ const from_auc = async (auc, from, to) => {
     
     transaction.status = 'auction'
     transaction.time = new Date()
-    transaction.card = auc.card
+    transaction.cards = [auc.card]
     transaction.price = auc.price
     transaction.guild_id = auc.guild
 
@@ -105,7 +105,7 @@ const confirm_trs = async (ctx, user, trs_id) => {
                 auditDB.transprice =  transaction.price
                 auditDB.audited = false
                 auditDB.user = transaction.to
-                auditDB.card = ctx.cards[x].name
+                auditDB.card = x
                 await auditDB.save()
             }
         })

--- a/staticdata/effects.js
+++ b/staticdata/effects.js
@@ -119,7 +119,7 @@ module.exports = [
     }, {
         id: 'judgeday',
         name: 'The Judgment Day',
-        desc: 'Grants effect of any useable card',
+        desc: 'Grants effect of any usable card',
         passive: false,
         cooldown: 48,
         use: async (ctx, user, args) => {

--- a/test/config.dest.json
+++ b/test/config.dest.json
@@ -9,7 +9,7 @@
     "invite": "",
     "maintenance": false,
     "auditc": {
-        "channel": "DISCORD_VALID_CHANNEL_ID_GOES_HERE",
+        "channel": ["DISCORD_VALID_CHANNEL_ID_GOES_HERE", "CAN TAKE MULTIPLE"],
         "taglogchannel": "DISCORD_VALID_CHANNEL_ID_GOES_HERE"
     },
     "evalc": {


### PR DESCRIPTION
Profile net worth/card value
Audit user tags is filterable by -removed, -banned, -clear and their ! variants
Fixed the dot operand to work as expected
Fixed diff over-riding -bid and !bid
Audit channel config is now an array of channel names
Fixes for to_id -> id issues
Add extra info on first tag about tags being global
Fixed audit not working with new transactions