### PR TITLE
Minor tweaks and audit additions

### DIFF
--- a/commands/auction.js
+++ b/commands/auction.js
@@ -248,8 +248,8 @@ cmd(['auc', 'bid'], 'bid', async (ctx, user, ...args) => {
     if(!auc)
         return ctx.reply(user, `auction with ID \`${id}\` wasn't found`, 'red')
 
-    if(user.exp < bid && (!auc.lastbidder === user.discord_id && user.exp < bid - auc.highbid))
-        return ctx.reply(user, `you don't have \`${bid}\` ${ctx.symbols.tomato} to bid`, 'red')        
+    if(user.exp < bid || (auc.lastbidder === user.discord_id && user.exp < bid - auc.highbid))
+        return ctx.reply(user, `you don't have \`${bid}\` ${ctx.symbols.tomato} to bid`, 'red')
 
     if(auc.expires < now || auc.finished)
         return ctx.reply(user, `auction \`${auc.id}\` already finished`, 'red')

--- a/commands/auction.js
+++ b/commands/auction.js
@@ -149,6 +149,9 @@ cmd(['auc', 'sell'], withCards(async (ctx, user, cards, parsedargs) => {
     if(parsedargs.isEmpty())
         return ctx.reply(user, `please specify card`, 'red')
 
+    if (user.dailystats.aucs >= 100)
+        return ctx.reply(user, `you have reached the maximum amount of auctions you can create in one daily. Please wait until your next daily to create more!`, 'red')
+
     const card = bestMatch(cards)
     const ceval = await evalCard(ctx, card)
     let price = parsedargs.extra.filter(x => x.length < 7 && !isNaN(x) && Number(x) > 0).map(x => Number(x))[0] || Math.round(ceval)

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -46,15 +46,14 @@ pcmd(['admin', 'auditor'], ['audit', 'help'], async (ctx, user, ...args) => {
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, curpgn)
 })
 
-pcmd(['admin', 'auditor'], ['fraud', 'report'], async (ctx, user, ...args) => {
+pcmd(['admin', 'auditor'], ['fraud', 'report'], async (ctx, user) => {
     if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
+    const help = ctx.audithelp.find(x => x.type === 'audit')
+    const curpgn = getHelpEmbed(ctx, help, ctx.guild.prefix)
 
-    return ctx.reply(user, `**__Choose a fraud report__**
-                            Fraud Report 1: Lists users who have more auction sales than returns
-                            Fraud Report 2: Lists overpriced auctions
-                            Fraud Report 3: Lists users who sold a card on auction and then bought the card back`)
+    return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, curpgn)
 
 })
 
@@ -129,6 +128,25 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '4'], async (ctx, user, ...args) 
         buttons: ['back', 'forward'],
         embed: {
             author: { name: `${user.username}, open report 4 audits: (${buybacks.length} results)` },
+            color: colors.blue,
+        }
+    })
+})
+
+pcmd(['admin', 'auditor'], ['fraud', 'report', '5'], async (ctx, user, ...args) => {
+    if (!ctx.audit.channel.includes(ctx.msg.channel.id))
+        return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
+
+    let botsells = await Audit.find({audited: false, report_type: 5})
+
+    if (botsells.length === 0)
+        return ctx.reply(user, 'nothing found for fraud report 5!')
+
+    return  ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
+        pages: paginate_auditReports(ctx, user, botsells, 5),
+        buttons: ['back', 'forward'],
+        embed: {
+            author: { name: `${user.username}, open report 5 audits: (${botsells.length} results)` },
             color: colors.blue,
         }
     })

--- a/commands/user.js
+++ b/commands/user.js
@@ -304,7 +304,7 @@ cmd('profile', async (ctx, user, ...args) => {
         } else {
             price = NaN
         }
-        if(card.level < 4) {
+        if(card.level < 4 && eval > 0) {
             vials += getVialCostFast(ctx, card, eval) * card.amount
         }
     })

--- a/modules/auction.js
+++ b/modules/auction.js
@@ -158,11 +158,10 @@ const finish_aucs = async (ctx, now) => {
         const aucCard = ctx.cards[auc.card]
         const eval = await evalCard(ctx, aucCard)
         await eval_fraud_check(ctx, auc, eval, aucCard)
-        if(!findSell){
+        if(!findSell)
             await audit_auc_stats(ctx, author, true)
-        }else {
+        else
             await AuditAucSell.findOneAndUpdate({ user: author.discord_id}, {$inc: {sold: 1}})
-        }
         // End audit logic
         await completed(ctx, lastBidder, aucCard)
         await lastBidder.save()
@@ -175,11 +174,10 @@ const finish_aucs = async (ctx, now) => {
             You ended up paying **${Math.round(auc.price)}** ${ctx.symbols.tomato} and got **${Math.round(auc.highbid - auc.price)}** ${ctx.symbols.tomato} back.
             ${tback > 0? `You got additional **${tback}** ${ctx.symbols.tomato} from your equipped effect` : ''}`)
     } else {
-        if(!findSell){
+        if(!findSell)
             await audit_auc_stats(ctx, author, false)
-        }else {
+        else
             await AuditAucSell.findOneAndUpdate({ user: author.discord_id}, {$inc: {unsold: 1}})
-        }
         addUserCard(author, auc.card)
         await author.save()
         await aucEvalChecks(ctx, auc, false)

--- a/modules/transaction.js
+++ b/modules/transaction.js
@@ -97,7 +97,6 @@ const confirm_trs = async (ctx, user, trs_id) => {
         transaction.cards.map(async (x) => {
             addUserCard(to_user, x)
             await completed(ctx, to_user, ctx.cards[x])
-            await trans_fraud_check(ctx, user, transaction, x)
         })
         await to_user.save()
         to_user.markModified('cards')
@@ -110,7 +109,10 @@ const confirm_trs = async (ctx, user, trs_id) => {
         return ctx.reply(user, `you don't have rights to confirm this transaction`, 'red')
     }
 
-    transaction.cards.map(x => removeUserCard(ctx, from_user, x))
+    transaction.cards.map(async (x) => {
+        removeUserCard(ctx, from_user, x)
+        await trans_fraud_check(ctx, user, transaction, x)
+    })
     await from_user.save()
     from_user.markModified('cards')
     await from_user.save()

--- a/staticdata/audithelp.json
+++ b/staticdata/audithelp.json
@@ -21,6 +21,10 @@
                 "description": "Same as report 3, but the person has to be the same person the auction went to"
             },
             {
+                "title": "->fraud report 5",
+                "description": "Displays when a user purchases a card via direct sale or auction and sells the card to bot"
+            },
+            {
                 "title": "->audit user [user_id]",
                 "description": "Lists all transactions done by the user"
             },

--- a/test/config.dest.json
+++ b/test/config.dest.json
@@ -22,7 +22,7 @@
             "maxSamples": 16,
             "minBounds": 0.5,
             "maxBounds": 5.0,
-            "aucFailMultiplier": 0.78,
+            "aucFailMultiplier": 0.90,
             "evalUpdateChannel": "DISCORD_VALID_CHANNEL_ID_GOES_HERE"
         }
     },


### PR DESCRIPTION
Added limiter to amount of auctions you can have per daily.

Added vial eval fix to profile like eval all has. 

Added a new fraud report and subsequent help entry for it

Tweaked auc fail multiplier. now that eval works on launch, more than 2-3 failures could cause a cascading price crash. 