### PR TITLE
Fix for auc add rejecting if your current balance is below bid amount

### DIFF
--- a/commands/auction.js
+++ b/commands/auction.js
@@ -245,10 +245,11 @@ cmd(['auc', 'bid'], 'bid', async (ctx, user, ...args) => {
 
     const auc = await Auction.findOne({id: id})
 
+    const lastBidder = auc.lastbidder === user.discord_id
     if(!auc)
         return ctx.reply(user, `auction with ID \`${id}\` wasn't found`, 'red')
 
-    if(user.exp < bid || (auc.lastbidder === user.discord_id && user.exp < bid - auc.highbid))
+    if((!lastBidder && user.exp < bid) || (lastBidder && user.exp < bid - auc.highbid))
         return ctx.reply(user, `you don't have \`${bid}\` ${ctx.symbols.tomato} to bid`, 'red')
 
     if(auc.expires < now || auc.finished)
@@ -260,7 +261,7 @@ cmd(['auc', 'bid'], 'bid', async (ctx, user, ...args) => {
     if(auc.price >= bid)
         return ctx.reply(user, `your bid should be higher than **${auc.price}** ${ctx.symbols.tomato}`, 'red')
 
-    if(auc.lastbidder === user.discord_id){
+    if(lastBidder){
         if (bid < auc.highbid)
             return ctx.reply(user, `you cannot lower how much you bid!`, 'red')
         await bid_auc(ctx, user, auc, bid, true)


### PR DESCRIPTION
previous overbid fix would not allow you to overbid your balance on auc add, which is required in some instances. As auc add takes into account what was already taken for your current bid