### PR TITLE
Many changes/additions. See description

### DIFF
--- a/collections/guild.js
+++ b/collections/guild.js
@@ -2,7 +2,7 @@ const {model, Schema} = require('mongoose')
 
 module.exports = model('Guild', {
     id:             { type: String, index: true },
-    prefix:         { type: String },
+    prefix:         { type: String, default: '->' },
     xp:             { type: Number, default: 0 },
     tax:            { type: Number, default: 0 },
     balance:        { type: Number, default: 0 },

--- a/commands/admin.js
+++ b/commands/admin.js
@@ -33,6 +33,10 @@ const {
     evalCardFast,
 } = require("../modules/eval");
 
+const {
+    numFmt,
+} = require('../utils/tools')
+
 const colors = require('../utils/colors')
 
 
@@ -91,7 +95,7 @@ pcmd(['admin', 'mod'], ['sudo', 'award'], ['sudo', 'add', 'balance'], async (ctx
 
         target.exp += amount
         await target.save()
-        rpl.push(`\`✅\` added '${amount}' ${ctx.symbols.tomato} to **${target.username}** (${target.discord_id})`)
+        rpl.push(`\`✅\` added '${numFmt(amount)}' ${ctx.symbols.tomato} to **${target.username}** (${target.discord_id})`)
     })
 
     return ctx.reply(user, rpl.join('\n'))
@@ -108,7 +112,7 @@ pcmd(['admin', 'mod'], ['sudo', 'add', 'vials'], async (ctx, user, ...args) => {
 
         target.vials += amount
         await target.save()
-        rpl.push(`\`✅\` added '${amount}' ${ctx.symbols.vial} to **${target.username}** (${target.discord_id})`)
+        rpl.push(`\`✅\` added '${numFmt(amount)}' ${ctx.symbols.vial} to **${target.username}** (${target.discord_id})`)
     })
 
     return ctx.reply(user, rpl.join('\n'))
@@ -232,9 +236,9 @@ pcmd(['admin', 'mod'], ['sudo', 'eval', 'info'], withGlobalCards(async (ctx, use
 
 
     if (lastEval > newEval)
-        evalDiff = `-${lastEval - newEval}`
+        evalDiff = `-${numFmt(lastEval - newEval)}`
     else
-        evalDiff = `+${newEval - lastEval}`
+        evalDiff = `+${numFmt(newEval - lastEval)}`
 
     let evalPrices = info.aucevalinfo.evalprices.length > 0? info.aucevalinfo.evalprices.join(', '): 'empty'
     let aucPrices = info.aucevalinfo.newaucprices.length > 0? info.aucevalinfo.newaucprices.join(', '): 'empty'
@@ -256,12 +260,12 @@ pcmd(['admin', 'mod'], ['sudo', 'eval', 'info'], withGlobalCards(async (ctx, use
             },
             {
                 name: "Old Eval",
-                value: `${lastEval}`,
+                value: `${numFmt(lastEval)}`,
                 inline: true
             },
             {
                 name: "New Eval",
-                value: `${newEval}`,
+                value: `${numFmt(newEval)}`,
                 inline: true
             },
             {

--- a/commands/auction.js
+++ b/commands/auction.js
@@ -1,4 +1,5 @@
 const {cmd}             = require('../utils/cmd')
+const {numFmt}          = require('../utils/tools')
 const {evalCard}        = require('../modules/eval')
 const {Auction}         = require('../collections')
 const {fetchOnly}       = require('../modules/user')
@@ -186,13 +187,13 @@ cmd(['auc', 'sell'], ['auction', 'sell'], withCards(async (ctx, user, cards, par
             return ctx.reply(user, `impossible to proceed with confirmation: ${formatName(card)} not found in your list`, 'red')
 
         if(price < min)
-            return ctx.reply(user, `you can't set price less than **${min}** ${ctx.symbols.tomato} for this card`, 'red')
+            return ctx.reply(user, `you can't set price less than **${numFmt(min)}** ${ctx.symbols.tomato} for this card`, 'red')
 
         if(price > max)
-            return ctx.reply(user, `you can't set price higher than **${max}** ${ctx.symbols.tomato} for this card`, 'red')
+            return ctx.reply(user, `you can't set price higher than **${numFmt(max)}** ${ctx.symbols.tomato} for this card`, 'red')
 
         if(user.exp < fee)
-            return ctx.reply(user, `you have to have at least **${fee}** ${ctx.symbols.tomato} to auction for that price`, 'red')
+            return ctx.reply(user, `you have to have at least **${numFmt(fee)}** ${ctx.symbols.tomato} to auction for that price`, 'red')
 
         if(usercard.fav && usercard.amount === 1)
             return ctx.reply(user, `you are about to put up last copy of your favourite card for sale. 
@@ -205,7 +206,7 @@ cmd(['auc', 'sell'], ['auction', 'sell'], withCards(async (ctx, user, cards, par
         ${(card.amount == 1 && card.rating)? 'You will lose your rating for this card' : ''}`
 
     ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
-        embed: { footer: { text: `This will cost ${fee} (${auchouse.level > 1? 5 : 10}% fee)` } },
+        embed: { footer: { text: `This will cost ${numFmt(fee)} (${auchouse.level > 1? 5 : 10}% fee)` } },
         force: ctx.globals.force,
         question,
         check,
@@ -226,7 +227,7 @@ cmd(['auc', 'sell'], ['auction', 'sell'], withCards(async (ctx, user, cards, par
                     price,
             })
 
-            ctx.reply(user, `you put ${formatName(card)} on auction for **${price}** ${ctx.symbols.tomato}
+            ctx.reply(user, `you put ${formatName(card)} on auction for **${numFmt(price)}** ${ctx.symbols.tomato}
                 Auction ID: \`${auc.id}\``)
         },
     })
@@ -257,7 +258,7 @@ cmd(['auc', 'bid'], ['auction', 'bid'], 'bid', async (ctx, user, ...args) => {
     const lastBidder = auc.lastbidder === user.discord_id
 
     if((!lastBidder && user.exp < bid) || (lastBidder && user.exp < bid - auc.highbid))
-        return ctx.reply(user, `you don't have \`${bid}\` ${ctx.symbols.tomato} to bid`, 'red')
+        return ctx.reply(user, `you don't have \`${numFmt(bid)}\` ${ctx.symbols.tomato} to bid`, 'red')
 
     if(auc.expires < now || auc.finished)
         return ctx.reply(user, `auction \`${auc.id}\` already finished`, 'red')
@@ -266,7 +267,7 @@ cmd(['auc', 'bid'], ['auction', 'bid'], 'bid', async (ctx, user, ...args) => {
         return ctx.reply(user, `you cannot bid on your own auction`, 'red')
 
     if(auc.price >= bid)
-        return ctx.reply(user, `your bid should be higher than **${auc.price}** ${ctx.symbols.tomato}`, 'red')
+        return ctx.reply(user, `your bid should be higher than **${numFmt(auc.price)}** ${ctx.symbols.tomato}`, 'red')
 
     if(lastBidder){
         if (bid < auc.highbid)

--- a/commands/auction.js
+++ b/commands/auction.js
@@ -24,7 +24,7 @@ const {
     getBuilding,
 } = require('../modules/guild')
 
-cmd('auc', withGlobalCards(async (ctx, user, cards, parsedargs) => {
+cmd('auc', 'auction', 'auctions', withGlobalCards(async (ctx, user, cards, parsedargs) => {
     const now = new Date();
     const req = {finished: false}
 
@@ -63,7 +63,7 @@ cmd('auc', withGlobalCards(async (ctx, user, cards, parsedargs) => {
     })
 })).access('dm')
 
-cmd(['auc', 'info'], async (ctx, user, arg1) => {
+cmd(['auc', 'info'], ['auction', 'info'], async (ctx, user, arg1) => {
     const auc = await Auction.findOne({ id: arg1 })
 
     if(!auc)
@@ -81,7 +81,7 @@ cmd(['auc', 'info'], async (ctx, user, arg1) => {
     }, user.discord_id)
 }).access('dm')
 
-cmd(['auc', 'info', 'all'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
+cmd(['auc', 'info', 'all'], ['auction', 'info', 'all'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
     const now = new Date();
     const req = {finished: false}
 
@@ -136,7 +136,7 @@ cmd(['auc', 'info', 'all'], withGlobalCards(async (ctx, user, cards, parsedargs)
     })
 })).access('dm')
 
-cmd(['auc', 'sell'], withCards(async (ctx, user, cards, parsedargs) => {
+cmd(['auc', 'sell'], ['auction', 'sell'], withCards(async (ctx, user, cards, parsedargs) => {
     const auchouse = getBuilding(ctx, 'auchouse')
     const timelimit = asdate.subtract(new Date(), 1, 'hour')
     const curaucs = await Auction.find({finished: false, author: user.discord_id, time: {$gt: timelimit}})
@@ -232,7 +232,7 @@ cmd(['auc', 'sell'], withCards(async (ctx, user, cards, parsedargs) => {
     })
 }))
 
-cmd(['auc', 'bid'], 'bid', async (ctx, user, ...args) => {
+cmd(['auc', 'bid'], ['auction', 'bid'], 'bid', async (ctx, user, ...args) => {
     if(user.ban && user.ban.embargo)
         return ctx.reply(user, `you are not allowed to list cards at auction.
                                 Your dealings were found to be in violation of our community rules.
@@ -250,9 +250,11 @@ cmd(['auc', 'bid'], 'bid', async (ctx, user, ...args) => {
 
     const auc = await Auction.findOne({id: id})
 
-    const lastBidder = auc.lastbidder === user.discord_id
+
     if(!auc)
         return ctx.reply(user, `auction with ID \`${id}\` wasn't found`, 'red')
+
+    const lastBidder = auc.lastbidder === user.discord_id
 
     if((!lastBidder && user.exp < bid) || (lastBidder && user.exp < bid - auc.highbid))
         return ctx.reply(user, `you don't have \`${bid}\` ${ctx.symbols.tomato} to bid`, 'red')
@@ -276,7 +278,7 @@ cmd(['auc', 'bid'], 'bid', async (ctx, user, ...args) => {
 
 }).access('dm')
 
-cmd(['auc', 'cancel'], async (ctx, user, arg1, arg2) => {
+cmd(['auc', 'cancel'], ['auction', 'cancel'], async (ctx, user, arg1, arg2) => {
     let auc = await Auction.findOne({ id: arg1 })
 
     if(!auc)

--- a/commands/auction.js
+++ b/commands/auction.js
@@ -1,11 +1,15 @@
 const {cmd}             = require('../utils/cmd')
 const {numFmt}          = require('../utils/tools')
 const {evalCard}        = require('../modules/eval')
-const {Auction}         = require('../collections')
 const {fetchOnly}       = require('../modules/user')
 const msToTime          = require('pretty-ms')
 const colors            = require('../utils/colors')
 const asdate            = require('add-subtract-date')
+
+const {
+    Auction,
+    User,
+} = require('../collections')
 
 const {
     new_auc,
@@ -229,6 +233,8 @@ cmd(['auc', 'sell'], ['auction', 'sell'], withCards(async (ctx, user, cards, par
 
             ctx.reply(user, `you put ${formatName(card)} on auction for **${numFmt(price)}** ${ctx.symbols.tomato}
                 Auction ID: \`${auc.id}\``)
+            const wishes = await User.find({heroslots: "festivewish", wishlist: card.id})
+            wishes.map(async (x) => await ctx.direct(x, `an auction for the card ${formatName(card)} on your wishlist has gone up on auction at \`${auc.id}\` for **${numFmt(price)}**${ctx.symbols.tomato}!`))
         },
     })
 }))

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -2,6 +2,7 @@ const {pcmd}                    = require('../utils/cmd')
 const {evalCard}                = require('../modules/eval')
 const {getHelpEmbed}            = require('../commands/misc')
 const {fetchOnly}               = require('../modules/user')
+const {numFmt}                  = require('../utils/tools')
 const colors                    = require('../utils/colors')
 const msToTime                  = require('pretty-ms')
 const dateFormat                = require(`dateformat`)
@@ -70,7 +71,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '1'], async (ctx, user, ...args) 
         pages: paginate_auditReports(ctx, user, overSell, 1),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: `${user.username}, open report 1 audits: (${overSell.length} results)` },
+            author: { name: `${user.username}, open report 1 audits: (${numFmt(overSell.length)} results)` },
             color: colors.blue,
         }
     })
@@ -89,7 +90,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '2'], async (ctx, user, ...args) 
         pages: paginate_auditReports(ctx, user, overPrice, 2),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: `${user.username}, open report 2 audits: (${overPrice.length} results)` },
+            author: { name: `${user.username}, open report 2 audits: (${numFmt(overPrice.length)} results)` },
             color: colors.blue,
         }
     })
@@ -108,7 +109,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '3'], async (ctx, user, ...args) 
         pages: paginate_auditReports(ctx, user, buybacks, 3),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: `${user.username}, open report 3 audits: (${buybacks.length} results)` },
+            author: { name: `${user.username}, open report 3 audits: (${numFmt(buybacks.length)} results)` },
             color: colors.blue,
         }
     })
@@ -127,7 +128,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '4'], async (ctx, user, ...args) 
         pages: paginate_auditReports(ctx, user, buybacks, 4),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: `${user.username}, open report 4 audits: (${buybacks.length} results)` },
+            author: { name: `${user.username}, open report 4 audits: (${numFmt(buybacks.length)} results)` },
             color: colors.blue,
         }
     })
@@ -146,7 +147,7 @@ pcmd(['admin', 'auditor'], ['fraud', 'report', '5'], async (ctx, user, ...args) 
         pages: paginate_auditReports(ctx, user, botsells, 5),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: `${user.username}, open report 5 audits: (${botsells.length} results)` },
+            author: { name: `${user.username}, open report 5 audits: (${numFmt(botsells.length)} results)` },
             color: colors.blue,
         }
     })
@@ -201,7 +202,7 @@ pcmd(['admin', 'auditor'], ['audit', 'user'], async (ctx, user, ...args) => {
         pages: paginate_trslist(ctx, auditedUser, list),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: `${user.username}, here are the results for ${auditedUser.username} (${list.length} results)` },
+            author: { name: `${user.username}, here are the results for ${auditedUser.username} (${numFmt(list.length)} results)` },
             color: colors.blue,
         }
     })
@@ -274,7 +275,7 @@ pcmd(['admin', 'auditor'], ['audit', 'trans'], async (ctx, user, ...arg) => {
     const corespAudit = await Audit.findOne({transid: arg[0]})
 
     const resp = []
-    resp.push(`Price: **${trans.price}** ${ctx.symbols.tomato}`)
+    resp.push(`Price: **${numFmt(trans.price)}** ${ctx.symbols.tomato}`)
     resp.push(`From: **${trans.from}** \`${trans.from_id}\``)
     resp.push(`To: **${trans.to}** \`${trans.to_id}\``)
     resp.push(`On server: **${trans.guild}** \`${trans.guild_id}\``)
@@ -338,7 +339,7 @@ pcmd(['admin', 'auditor'], ['audit', 'auc'], ['audit', 'auction'], async (ctx, u
     const resp = []
 
     resp.push(`Seller: **${author.username}** \`${author.discord_id}\``)
-    resp.push(`Price: **${auc.price}** ${ctx.symbols.tomato}`)
+    resp.push(`Price: **${numFmt(auc.price)}** ${ctx.symbols.tomato}`)
     resp.push(`Card: ${formatName(card)}`)
     resp.push(`Card value: **${await evalCard(ctx, card)}** ${ctx.symbols.tomato}`)
 
@@ -399,12 +400,12 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args)
     let embed = {
         author: {name: `${user.username} here is the info for ${findUser.username}`},
         description: `**${findUser.username}** \`${findUser.discord_id}\`
-                      Currency: **${findUser.exp}${ctx.symbols.tomato}**, **${findUser.vials}${ctx.symbols.vial}**
-                      Promo Currency: **${findUser.promoexp}**
+                      Currency: **${numFmt(findUser.exp)}${ctx.symbols.tomato}**, **${numFmt(findUser.vials)}${ctx.symbols.vial}**
+                      Promo Currency: **${numFmt(findUser.promoexp)}**
                       Embargoed?: **${findUser.ban.embargo? 'true': 'false'}**
                       Join Date: **${dateFormat(findUser.joined, "yyyy-mm-dd HH:MM:ss")}**
                       Last Daily: **${dateFormat(findUser.lastdaily, "yyyy-mm-dd HH:MM:ss")}**
-                      Unique Cards: **${findUser.cards.length}**
+                      Unique Cards: **${numFmt(findUser.cards.length)}**
                       Completed Collections: **${findUser.completedcols? findUser.completedcols.length: 0}**
                       Effects List: **${effects.length !== 0? effects: 'none'}**
                       __Daily Stats__: 
@@ -439,12 +440,12 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'obj'], ['audit', 'find', 'object']
     let embed = {
         author: {name: `${user.username} here is the info for ${findUser.username}`},
         description: `**${findUser.username}** \`${findUser.discord_id}\`
-                      Currency: **${findUser.exp}${ctx.symbols.tomato}**, **${findUser.vials}${ctx.symbols.vial}**
-                      Promo Currency: **${findUser.promoexp}**
-                      Embargoed?: **${findUser.ban.embargo}**
+                      Currency: **${numFmt(findUser.exp)}${ctx.symbols.tomato}**, **${numFmt(findUser.vials)}${ctx.symbols.vial}**
+                      Promo Currency: **${numFmt(findUser.promoexp)}**
+                      Embargoed?: **${findUser.ban.embargo? 'true': 'false'}**
                       Join Date: **${dateFormat(findUser.joined, "yyyy-mm-dd HH:MM:ss")}**
                       Last Daily: **${dateFormat(findUser.lastdaily, "yyyy-mm-dd HH:MM:ss")}**
-                      Unique Cards: **${findUser.cards.length}**
+                      Unique Cards: **${numFmt(findUser.cards.length)}**
                       Completed Collections: **${findUser.completedcols? findUser.completedcols.length: 0}**
                       Effects List: **${effects.length !== 0? effects: 'none'}**
                       __Daily Stats__: 
@@ -469,7 +470,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'trans'], withGlobalCards(async (ct
         pages: paginate_guildtrslist(ctx, user, list),
         buttons: ['back', 'forward'],
         embed: {
-            author: { name: `${user.username}, matched ${cards.length} cards and ${list.length} transactions` },
+            author: { name: `${user.username}, matched ${cards.length} cards and ${numFmt(list.length)} transactions` },
             color: colors.blue,
         }
     })
@@ -531,6 +532,6 @@ pcmd(['admin', 'auditor'], ['audit', 'list'], ['audit', 'li'], ['audit', 'cards'
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(cardstr, 15),
-        embed: { author: { name: `${user.username}, here are ${findUser.username}'s cards (${findCards.length} results)` } }
+        embed: { author: { name: `${user.username}, here are ${findUser.username}'s cards (${numFmt(findCards.length)} results)` } }
     })
 })

--- a/commands/audit.js
+++ b/commands/audit.js
@@ -401,7 +401,7 @@ pcmd(['admin', 'auditor'], ['audit', 'find', 'user'], async (ctx, user, ...args)
         description: `**${findUser.username}** \`${findUser.discord_id}\`
                       Currency: **${findUser.exp}${ctx.symbols.tomato}**, **${findUser.vials}${ctx.symbols.vial}**
                       Promo Currency: **${findUser.promoexp}**
-                      Embargoed?: **${findUser.ban.embargo}**
+                      Embargoed?: **${findUser.ban.embargo? 'true': 'false'}**
                       Join Date: **${dateFormat(findUser.joined, "yyyy-mm-dd HH:MM:ss")}**
                       Last Daily: **${dateFormat(findUser.lastdaily, "yyyy-mm-dd HH:MM:ss")}**
                       Unique Cards: **${findUser.cards.length}**

--- a/commands/card.js
+++ b/commands/card.js
@@ -10,6 +10,7 @@ const _ = require('lodash')
 const {
     claimCost, 
     promoClaimCost,
+    numFmt,
 } = require('../utils/tools')
 
 const {
@@ -80,12 +81,12 @@ cmd('claim', 'cl', async (ctx, user, ...args) => {
         return ctx.reply(user, `you can claim only **10** or less cards with one command`, 'red')
 
     if(!promo && price > user.exp)
-        return ctx.reply(user, `you need **${price}** ${ctx.symbols.tomato} to claim ${amount > 1? amount + ' cards' : 'a card'}. 
-            You have **${Math.floor(user.exp)}** ${ctx.symbols.tomato}`, 'red')
+        return ctx.reply(user, `you need **${numFmt(price)}** ${ctx.symbols.tomato} to claim ${amount > 1? amount + ' cards' : 'a card'}. 
+            You have **${numFmt(Math.floor(user.exp))}** ${ctx.symbols.tomato}`, 'red')
 
     if(promo && price > user.promoexp)
-        return ctx.reply(user, `you need **${price}** ${promo.currency} to claim ${amount > 1? amount + ' cards' : 'a card'}. 
-            You have **${Math.floor(user.promoexp)}** ${promo.currency}`, 'red')
+        return ctx.reply(user, `you need **${numFmt(price)}** ${promo.currency} to claim ${amount > 1? amount + ' cards' : 'a card'}. 
+            You have **${numFmt(Math.floor(user.promoexp))}** ${promo.currency}`, 'red')
 
     if(!promo) {
         boost = curboosts.find(x => args.some(y => y === x.id))
@@ -167,12 +168,12 @@ cmd('claim', 'cl', async (ctx, user, ...args) => {
     let description = `**${user.username}**, you got:`
     fields.push({name: `New cards`, value: newCards.map(x => `${x.boostdrop? '`🅱` ' : ''}${formatName(x.card)}`).join('\n')})
     fields.push({name: `Duplicates`, value: oldCards.map(x => `${x.boostdrop? '`🅱` ' : ''}${formatName(x.card)} #${x.count}`).join('\n')})
-    fields.push({name: `Receipt`, value: `You spent **${price}** ${curr} in total
-        You have **${Math.round(promo? user.promoexp : user.exp)}** ${curr} left
+    fields.push({name: `Receipt`, value: `You spent **${numFmt(price)}** ${curr} in total
+        You have **${numFmt(Math.round(promo? user.promoexp : user.exp))}** ${curr} left
         You can claim **${max - 1}** more cards
-        Your next claim will cost **${promo? promoClaimCost(user, 1) : claimCost(user, ctx.guild.tax, 1)}** ${curr}
-        ${activepromo && !promo? `You got **${extra}** ${activepromo.currency}
-        You now have **${user.promoexp}** ${activepromo.currency}` : ""}`.replace(/\s\s+/gm, '\n')})
+        Your next claim will cost **${promo? numFmt(promoClaimCost(user, 1)) : numFmt(claimCost(user, ctx.guild.tax, 1))}** ${curr}
+        ${activepromo && !promo? `You got **${numFmt(extra)}** ${activepromo.currency}
+        You now have **${numFmt(user.promoexp)}** ${activepromo.currency}` : ""}`.replace(/\s\s+/gm, '\n')})
     /*fields.push({name: `External view`, value:
         `[view your claimed cards here](http://noxcaos.ddns.net:3000/cards?type=claim&ids=${cards.map(x => x.card.id).join(',')})`})*/
 
@@ -234,7 +235,7 @@ cmd(['ls', 'global'], ['cards', 'global'], ['li', 'global'], ['list', 'global'],
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(cards.map(c => formatName(c)), 15),
         embed: {
-            author: { name: `Matched cards from database (${cards.length} results)` },
+            author: { name: `Matched cards from database (${numFmt(cards.length)} results)` },
         }
     })
 })).access('dm')
@@ -257,9 +258,9 @@ cmd('sell', withCards(async (ctx, user, cards, parsedargs) => {
 
     let question = ""
     if(trs.to != 'bot') {
-        question = `**${trs.to}**, **${trs.from}** wants to sell you **${formatName(card)}** for **${price}** ${ctx.symbols.tomato}`
+        question = `**${trs.to}**, **${trs.from}** wants to sell you **${formatName(card)}** for **${numFmt(price)}** ${ctx.symbols.tomato}`
     } else {
-        question = `**${trs.from}**, do you want to sell **${formatName(card)}** to **bot** for **${price}** ${ctx.symbols.tomato}?`
+        question = `**${trs.from}**, do you want to sell **${formatName(card)}** to **bot** for **${numFmt(price)}** ${ctx.symbols.tomato}?`
         perms.confirm.push(user.discord_id)
     }
 
@@ -306,9 +307,9 @@ cmd(['sell', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
 
     let question = ""
     if(trs.to != 'bot') {
-        question = `**${trs.to}**, **${trs.from}** wants to sell you **${cards.length} cards** for **${price}** ${ctx.symbols.tomato}`
+        question = `**${trs.to}**, **${trs.from}** wants to sell you **${cards.length} cards** for **${numFmt(price)}** ${ctx.symbols.tomato}`
     } else {
-        question = `**${trs.from}**, do you want to sell **${cards.length} cards** to **bot** for **${price}** ${ctx.symbols.tomato}?`
+        question = `**${trs.from}**, do you want to sell **${cards.length} cards** to **bot** for **${numFmt(price)}** ${ctx.symbols.tomato}?`
         perms.confirm.push(user.discord_id)
     }
 
@@ -356,7 +357,7 @@ cmd(['sell', 'preview'], withCards(async (ctx, user, cards, parsedargs) => {
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(resp.map(x => x.cardname), 10),
         embed: {
-            author: { name: `Sell all preview (total ${price} ${ctx.symbols.tomato})` },
+            author: { name: `Sell all preview (total ${numFmt(price)} ${ctx.symbols.tomato})` },
             description: '',
             color: colors.blue,
         }
@@ -372,7 +373,7 @@ cmd('eval', withGlobalCards(async (ctx, user, cards, parsedargs) => {
     const price = await evalCard(ctx, card)
     const vials = await getVialCost(ctx, card, price)
     return ctx.reply(user, 
-        `card ${formatName(card)} is worth: **${price}** ${ctx.symbols.tomato} ${card.level < 4? `or **${vials}** ${ctx.symbols.vial}` : ``}`)
+        `card ${formatName(card)} is worth: **${numFmt(price)}** ${ctx.symbols.tomato} ${card.level < 4? `or **${numFmt(vials)}** ${ctx.symbols.vial}` : ``}`)
 }))
 
 cmd(['eval', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
@@ -401,8 +402,8 @@ cmd(['eval', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
     }
 
     return ctx.reply(user, 
-        `request contains **${cards.length}** of your cards worth **${price}** ${ctx.symbols.tomato} 
-        ${vials > 0? `or **${vials}** ${ctx.symbols.vial} (for less than 4 stars)` : ``}`)
+        `request contains **${cards.length}** of your cards worth **${numFmt(price)}** ${ctx.symbols.tomato} 
+        ${vials > 0? `or **${numFmt(vials)}** ${ctx.symbols.vial} (for less than 4 stars)` : ``}`)
 }))
 
 cmd(['eval', 'all', 'global'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
@@ -431,8 +432,8 @@ cmd(['eval', 'all', 'global'], withGlobalCards(async (ctx, user, cards, parsedar
     }
 
     return ctx.reply(user, 
-        `your request contains **${cards.length}** cards worth **${price}** ${ctx.symbols.tomato} 
-        ${vials > 0? `or **${vials}** ${ctx.symbols.vial} (for less than 4 stars)` : ``}`)
+        `your request contains **${cards.length}** cards worth **${numFmt(price)}** ${ctx.symbols.tomato} 
+        ${vials > 0? `or **${numFmt(vials)}** ${ctx.symbols.vial} (for less than 4 stars)` : ``}`)
 }))
 
 cmd('fav', withCards(async (ctx, user, cards, parsedargs) => {
@@ -463,7 +464,7 @@ cmd(['fav', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         embed: { footer: { text: `Favourite cards can be accessed with -fav` } },
         force: ctx.globals.force,
-        question: `**${user.username}**, do you want to mark **${cards.length}** cards as favourite?`,
+        question: `**${user.username}**, do you want to mark **${numFmt(cards.length)}** cards as favourite?`,
         onConfirm: async (x) => {
             cards.map(c => {
                  user.cards[user.cards.findIndex(x => x.id == c.id)].fav = true
@@ -472,7 +473,7 @@ cmd(['fav', 'all'], withCards(async (ctx, user, cards, parsedargs) => {
             user.markModified('cards')
             await user.save()
 
-            return ctx.reply(user, `marked **${cards.length}** cards as favourite`)
+            return ctx.reply(user, `marked **${numFmt(cards.length)}** cards as favourite`)
         }
     })
 })).access('dm')
@@ -504,7 +505,7 @@ cmd(['unfav', 'all'], ['fav', 'remove', 'all'], withCards(async (ctx, user, card
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         force: ctx.globals.force,
-        question: `**${user.username}**, do you want to remove **${cards.length}** cards from favourites?`,
+        question: `**${user.username}**, do you want to remove **${numFmt(cards.length)}** cards from favourites?`,
         onConfirm: async (x) => {
             cards.map(c => {
                  user.cards[user.cards.findIndex(x => x.id == c.id)].fav = false
@@ -513,7 +514,7 @@ cmd(['unfav', 'all'], ['fav', 'remove', 'all'], withCards(async (ctx, user, card
             user.markModified('cards')
             await user.save()
 
-            return ctx.reply(user, `removed **${cards.length}** cards from favourites`)
+            return ctx.reply(user, `removed **${numFmt(cards.length)}** cards from favourites`)
         }
     })
 })).access('dm')
@@ -549,7 +550,7 @@ cmd(['boost', 'info'], (ctx, user, args) => {
 
     const list = []
     list.push(`Rate: **${boost.rate * 100}%**`)
-    list.push(`Cards in pool: **${boost.cards.length}**`)
+    list.push(`Cards in pool: **${numFmt(boost.cards.length)}**`)
     list.push(`Command: \`${ctx.prefix}claim ${boost.id}\``)
     list.push(`Expires in **${msToTime(boost.expires - now)}**`)
 
@@ -637,7 +638,7 @@ cmd(['wish', 'list'], ['wish', 'ls'], ['wishlist', 'list'], ['wishlist', 'ls'], 
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(cards.map(x => `${formatName(x)}`), 15),
-        embed: { author: { name: `${user.username}, your wishlist (${cards.length} results)` } }
+        embed: { author: { name: `${user.username}, your wishlist (${numFmt(cards.length)} results)` } }
     })
 })).access('dm')
 
@@ -669,14 +670,14 @@ cmd(['wish', 'add', 'all'], ['wishlist', 'add', 'all'], withGlobalCards(async (c
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         force: ctx.globals.force,
-        question: `**${user.username}**, do you want add **${cards.length}** cards to your wishlist?`,
+        question: `**${user.username}**, do you want add **${numFmt(cards.length)}** cards to your wishlist?`,
         onConfirm: async (_x) => {
             cards.map(c => {
                 user.wishlist.push(c.id)
             })
             await user.save()
 
-            return ctx.reply(user, `added **${cards.length}** cards to your wishlist`)
+            return ctx.reply(user, `added **${numFmt(cards.length)}** cards to your wishlist`)
         }
     })
 })).access('dm')
@@ -712,12 +713,12 @@ cmd(['wish', 'rm', 'all'], ['wish', 'remove', 'all'], ['wishlist', 'remove', 'al
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         force: ctx.globals.force,
-        question: `**${user.username}**, do you want remove **${cards.length}** cards from your wishlist?`,
+        question: `**${user.username}**, do you want remove **${numFmt(cards.length)}** cards from your wishlist?`,
         onConfirm: async (_x) => {
             user.wishlist = user.wishlist.filter(y => !cards.some(c => c.id === y))
             await user.save()
 
-            return ctx.reply(user, `removed **${cards.length}** cards from your wishlist`)
+            return ctx.reply(user, `removed **${numFmt(cards.length)}** cards from your wishlist`)
         }
     })
 })).access('dm')

--- a/commands/card.js
+++ b/commands/card.js
@@ -625,7 +625,7 @@ cmd(['rate', 'remove'], ['unrate'], withCards(async (ctx, user, cards, parsedarg
     return ctx.reply(user, `removed rating for ${formatName(card)}`)
 })).access('dm')
 
-cmd(['wish'], ['wishlist'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
+cmd(['wish', 'list'], ['wish', 'ls'], ['wishlist', 'list'], ['wishlist', 'ls'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
     if(user.wishlist.length === 0) {
         return ctx.reply(user, `your wishlist is empty. Use \`${ctx.prefix}wish add [card]\` to add cards to your wishlist`)
     }
@@ -641,7 +641,7 @@ cmd(['wish'], ['wishlist'], withGlobalCards(async (ctx, user, cards, parsedargs)
     })
 })).access('dm')
 
-cmd(['wish', 'add'], ['wishlist', 'add'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
+cmd(['wish'], ['wishlist'], ['wish', 'add'], ['wishlist', 'add'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
     if(parsedargs.isEmpty())
         return ctx.qhelp(ctx, user, 'wishlist')
 

--- a/commands/collection.js
+++ b/commands/collection.js
@@ -9,8 +9,12 @@ const {
     mapUserCards,
 } = require('../modules/card')
 
+const {
+    nameSort,
+    numFmt,
+}    = require('../utils/tools')
+
 const {cmd}         = require('../utils/cmd')
-const {nameSort}    = require('../utils/tools')
 const colors        = require('../utils/colors')
 const _             = require('lodash')
 
@@ -73,8 +77,8 @@ cmd(['col', 'info'], ['collection', 'info'], async (ctx, user, ...args) => {
     const ratingAvg = ratingSum / colInfos.reduce((acc, cur) => acc + cur.usercount, 0)
 
     const resp = []
-    resp.push(`Overall cards: **${colCards.length}**`)
-    resp.push(`You have: **${userCards.length} (${((userCards.length / colCards.length) * 100).toFixed(2)}%)**`)
+    resp.push(`Overall cards: **${numFmt(colCards.length)}**`)
+    resp.push(`You have: **${numFmt(userCards.length)} (${((userCards.length / colCards.length) * 100).toFixed(2)}%)**`)
     resp.push(`Average rating: **${ratingAvg.toFixed(2)}**`)
 
     if(clout && clout.amount > 0)

--- a/commands/guild.js
+++ b/commands/guild.js
@@ -6,6 +6,7 @@ const asdate            = require('add-subtract-date')
 const {
     XPtoLEVEL,
     LEVELtoXP,
+    numFmt,
 } = require('../utils/tools')
 
 const {
@@ -52,7 +53,7 @@ cmd(['guild', 'info'], async (ctx, user, ...args) => {
     const nextxp = LEVELtoXP(guildlvl + 1)
     const channels = ctx.guild.botchannels.filter(x => ctx.discord_guild.channels.some(y => y.id === x))
     resp.push(`Level: **${guildlvl}** (${(((ctx.guild.xp - prevxp)/(nextxp - prevxp)) * 100).toFixed(1)}%)`)
-    resp.push(`Players: **${ctx.guild.userstats.length}/${ctx.discord_guild.memberCount}**`)
+    resp.push(`Players: **${numFmt(ctx.guild.userstats.length)}/${numFmt(ctx.discord_guild.memberCount)}**`)
     resp.push(`Prefix: \`${ctx.guild.prefix || ctx.prefix}\``)
     resp.push(`Claim tax: **${Math.round(ctx.guild.tax * 100)}%**`)
     resp.push(`Building permissions: **Rank ${ctx.guild.buildperm}+**`)
@@ -108,13 +109,13 @@ cmd(['guild', 'status'], (ctx, user) => {
     const total = Math.round(cost - cost * ctx.guild.discount)
     const ratio = total / ctx.guild.balance
 
-    resp.push(`Building maintenance: **${cost}** ${ctx.symbols.tomato}/day`)
+    resp.push(`Building maintenance: **${numFmt(cost)}** ${ctx.symbols.tomato}/day`)
 
     if(ctx.guild.discount > 0) {
         resp.push(`Maintenance discount: **${ctx.guild.discount * 100}%**`)
-        resp.push(`Subtotal after discounts: **${total}** ${ctx.symbols.tomato}/day`)
+        resp.push(`Subtotal after discounts: **${numFmt(total)}** ${ctx.symbols.tomato}/day`)
     }
-    resp.push(`Current finances: **${ctx.guild.balance}** ${ctx.symbols.tomato}`)
+    resp.push(`Current finances: **${numFmt(ctx.guild.balance)}** ${ctx.symbols.tomato}`)
     resp.push(`Ratio: **${ratio.toFixed(2)}** (${ratio <= 1? 'positive' : 'negative'})`)
     resp.push(`Maintenance charges in **${msToTime(ctx.guild.nextcheck - new Date(), {compact: true})}**`)
     resp.push(`> Make sure you have **positive** ratio when maintenance costs are charged`)
@@ -125,7 +126,7 @@ cmd(['guild', 'status'], (ctx, user) => {
         fields: [{name: `Maintenance breakdown`, value: ctx.guild.buildings.map(x => {
             const item = ctx.items.find(y => y.id === x.id)
             const heart = x.health < 50? '💔' : '❤️'
-            return `[\`${heart}\` ${x.health}] **${item.name}** level **${x.level}** costs **${item.levels[x.level - 1].maintenance}** ${ctx.symbols.tomato}/day`
+            return `[\`${heart}\` ${x.health}] **${item.name}** level **${x.level}** costs **${numFmt(item.levels[x.level - 1].maintenance)}** ${ctx.symbols.tomato}/day`
         }).join('\n')}],
         color: (ratio <= 1? color.green : color.red)
     }, user.discord_id)
@@ -155,9 +156,9 @@ cmd(['guild', 'upgrade'], async (ctx, user, arg1) => {
         return ctx.reply(user, `this guild has to be at least level **${level.level}** to have **${item.name} level ${building.level + 1}**`, 'red')
 
     if(user.exp < level.price)
-        return ctx.reply(user, `you have to have at least **${level.price}** ${ctx.symbols.tomato} to upgrade this building`, 'red')
+        return ctx.reply(user, `you have to have at least **${numFmt(level.price)}** ${ctx.symbols.tomato} to upgrade this building`, 'red')
 
-    const question = `Do you want to upgrade **${item.name}** to level **${building.level + 1}** for **${level.price}** ${ctx.symbols.tomato}?`
+    const question = `Do you want to upgrade **${item.name}** to level **${building.level + 1}** for **${numFmt(level.price)}** ${ctx.symbols.tomato}?`
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         question,
         force: ctx.globals.force,
@@ -241,9 +242,9 @@ cmd(['guild', 'donate'], async (ctx, user, arg1) => {
 
     amount = Math.abs(amount)
     if(user.exp < amount)
-        return ctx.reply(user, `you don't have **${amount}** ${ctx.symbols.tomato} to donate`, 'red')
+        return ctx.reply(user, `you don't have **${numFmt(amount)}** ${ctx.symbols.tomato} to donate`, 'red')
 
-    const question = `Do you want to donate **${amount}** ${ctx.symbols.tomato} to **${ctx.discord_guild.name}**?`
+    const question = `Do you want to donate **${numFmt(amount)}** ${ctx.symbols.tomato} to **${ctx.discord_guild.name}**?`
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         question,
         force: ctx.globals.force,
@@ -257,7 +258,7 @@ cmd(['guild', 'donate'], async (ctx, user, arg1) => {
             await user.save()
             await ctx.guild.save()
 
-            return ctx.reply(user, `you donated **${amount}** ${ctx.symbols.tomato} to **${ctx.discord_guild.name}**!
+            return ctx.reply(user, `you donated **${numFmt(amount)}** ${ctx.symbols.tomato} to **${ctx.discord_guild.name}**!
                 This now has **${ctx.guild.balance}** ${ctx.symbols.tomato}
                 You have been awarded **${Math.floor(xp)} xp** towards your next rank`)
         }
@@ -406,7 +407,7 @@ cmd(['guild', 'lock'], async (ctx, user, arg1) => {
 
     const price = guildLock.price
     if(ctx.guild.balance < price)
-        return ctx.reply(user, `this guild doesn't have **${price}** ${ctx.symbols.tomato} required for a lock`, 'red')
+        return ctx.reply(user, `this guild doesn't have **${numFmt(price)}** ${ctx.symbols.tomato} required for a lock`, 'red')
 
     arg1 = arg1.replace('-', '')
     const col = bestColMatch(ctx, arg1)
@@ -435,10 +436,10 @@ cmd(['guild', 'lock'], async (ctx, user, arg1) => {
     if(future > now)
         return ctx.reply(user, `you can use lock in **${msToTime(future - now, { compact: true })}**`, 'red')
 
-    const question = `Do you want lock this guild to **${col.name}** using **${price}** ${ctx.symbols.tomato} ?
-        >>> This will add **${guildLock.maintenance}** ${ctx.symbols.tomato} to guild maintenance.
+    const question = `Do you want lock this guild to **${col.name}** using **${numFmt(price)}** ${ctx.symbols.tomato} ?
+        >>> This will add **${numFmt(guildLock.maintenance)}** ${ctx.symbols.tomato} to guild maintenance.
         Lock will be paused if guild balance goes negative.
-        Locking to another collection will cost **${price}** ${ctx.symbols.tomato}
+        Locking to another collection will cost **${numFmt(price)}** ${ctx.symbols.tomato}
         You won't be able to change lock for 7 days.
         You can unlock any time.
         Users will still be able to claim cards from general pool using \`->claim any\``
@@ -456,7 +457,7 @@ cmd(['guild', 'lock'], async (ctx, user, arg1) => {
             await ctx.guild.save()
 
             return ctx.reply(user, `you locked **${ctx.discord_guild.name}** to **${col.name}**
-                Claim pool now consists of **${colCards.length}** cards`)
+                Claim pool now consists of **${numFmt(colCards.length)}** cards`)
 
         }, 
         onDecline: (x) => ctx.reply(user, 'operation was cancelled. Guild lock was not applied', 'red')
@@ -486,7 +487,7 @@ cmd(['guild', 'unlock'], async (ctx, user) => {
             await ctx.guild.save()
 
             return ctx.reply(user, `guild lock has been removed.
-                Claim pool now consists of **${colCards.length}** cards`)
+                Claim pool now consists of **${numFmt(colCards.length)}** cards`)
         }
     })
 })

--- a/commands/guild.js
+++ b/commands/guild.js
@@ -304,7 +304,7 @@ cmd(['guild', 'set', 'report'], async (ctx, user) => {
 
 cmd(['guild', 'set', 'bot'], async (ctx, user) => {
     if(ctx.guild.botchannels.length > 0 && !isUserOwner(ctx, user) && !user.roles.includes('admin'))
-        return ctx.reply(user, `only owner can change guild's report channel`, 'red')
+        return ctx.reply(user, `only server owner can add bot channels`, 'red')
 
     if(ctx.guild.botchannels.includes(ctx.msg.channel.id))
         return ctx.reply(user, `this channel is already marked as bot channel`, 'red')
@@ -317,7 +317,7 @@ cmd(['guild', 'set', 'bot'], async (ctx, user) => {
 
 cmd(['guild', 'unset', 'bot'], async (ctx, user) => {
     if(!isUserOwner(ctx, user) && !user.roles.includes('admin'))
-        return ctx.reply(user, `only owner can change guild's report channel`, 'red')
+        return ctx.reply(user, `only server owner can remove bot channels`, 'red')
 
     const pulled = ctx.guild.botchannels.pull(ctx.msg.channel.id)
     if(pulled.length === 0)

--- a/commands/hero.js
+++ b/commands/hero.js
@@ -11,6 +11,7 @@ const {
 
 const {
     XPtoLEVEL,
+    numFmt,
 } = require('../utils/tools')
 
 const {
@@ -326,7 +327,7 @@ cmd(['hero', 'submit'], async (ctx, user, arg1) => {
 
     const price = 512 * (2 ** user.herosubmits)
     if(user.exp < price)
-        return ctx.reply(user, `you have to have at least **${price}** ${ctx.symbols.tomato} to submit a hero`, 'red')
+        return ctx.reply(user, `you have to have at least **${numFmt(price)}** ${ctx.symbols.tomato} to submit a hero`, 'red')
 
     const charID = arg1.replace('https://', '').split('/')[2]
     if(!charID)
@@ -372,6 +373,7 @@ cmd(['hero', 'submit'], async (ctx, user, arg1) => {
     const embed = { 
         title: `Submitting a hero`,
         description: `You are about to submit **${char.name.english}** from **${media.title.english}**.
+        > This submission will cost you **${numFmt(price)}** ${ctx.symbols.tomato}
         > It may take up some time to review the character. You will keep your current hero while the submission is being processed.
         Proceed?`,
         image: { url: char.image.large }

--- a/commands/meta.js
+++ b/commands/meta.js
@@ -5,6 +5,7 @@ const dateFormat    = require('dateformat')
 
 const colors        = require('../utils/colors')
 const {cmd, pcmd}   = require('../utils/cmd')
+const {numFmt}      = require('../utils/tools')
 
 const {
     fetchCardTags,
@@ -50,7 +51,7 @@ cmd('info', ['card', 'info'], withGlobalCards(async (ctx, user, cards, parsedarg
 
     resp.push(formatName(card))
     resp.push(`Fandom: **${col.name}**`)
-    resp.push(`Price: **${price}** ${ctx.symbols.tomato}`)
+    resp.push(`Price: **${numFmt(price)}** ${ctx.symbols.tomato}`)
 
     if(extrainfo.ratingsum > 0)
         resp.push(`Average Rating: **${(extrainfo.ratingsum / extrainfo.usercount).toFixed(2)}**`)
@@ -62,10 +63,10 @@ cmd('info', ['card', 'info'], withGlobalCards(async (ctx, user, cards, parsedarg
         resp.push(`Added: **${dateFormat(card.added, "yyyy-mm-dd")}** (${msToTime(new Date() - card.added, {compact: true})})`)
 
     if (extrainfo.ownercount > 0)
-        resp.push(`Owner Count: **${extrainfo.ownercount}**`)
+        resp.push(`Owner Count: **${numFmt(extrainfo.ownercount)}**`)
 
     if (extrainfo.auccount > 0)
-        resp.push(`Times Auctioned: **${extrainfo.aucevalinfo.auccount}**`)
+        resp.push(`Times Auctioned: **${numFmt(extrainfo.aucevalinfo.auccount)}**`)
 
     resp.push(`ID: ${card.id}`)
     embed.description = resp.join('\n')

--- a/commands/misc.js
+++ b/commands/misc.js
@@ -36,13 +36,13 @@ cmd('help', async (ctx, user, ...args) => {
 
             if(ch.id != ctx.msg.channel.id)
                 await ctx.reply(user, `help was sent to you. 
-                    You can also use *-here* (e.g. \`${ctx.guild.prefix}help guild -here\`) to see help in the current channel`)
+                    You can also use \`-here\` (e.g. \`${ctx.guild.prefix}help guild -here\`) to see help in the current channel`)
 
         } catch (e) {
             await ctx.reply(user, `failed to send direct message to you ੨( ･᷄ ︵･᷅ )ｼ
                 Please make sure you have **Allow direct messages from server members** enabled in server privacy settings.
                 You can do it in any server that you share with bot.
-                You also can add *-here* (e.g. \`${ctx.guild.prefix}help guild -here\`) to see help in the current channel`, 'red')
+                You also can add \`-here\` (e.g. \`${ctx.guild.prefix}help guild -here\`) to see help in the current channel`, 'red')
         }
     }
 }).access('dm')

--- a/commands/smith.js
+++ b/commands/smith.js
@@ -1,4 +1,5 @@
 const {cmd}     = require('../utils/cmd')
+const {numFmt}  = require('../utils/tools')
 const colors    = require('../utils/colors')
 const msToTime  = require('pretty-ms')
 const _         = require('lodash')
@@ -76,13 +77,13 @@ cmd(['forge'], withMultiQuery(async (ctx, user, cards, parsedargs) => {
     const vialres = Math.round((vialavg === Infinity? 0 : vialavg) * .5)
 
     if(user.exp < cost)
-        return ctx.reply(user, `you need at least **${cost}** ${ctx.symbols.tomato} to forge these cards`, 'red')
+        return ctx.reply(user, `you need at least **${numFmt(cost)}** ${ctx.symbols.tomato} to forge these cards`, 'red')
 
     if((card1.fav && card1.amount == 1) || (card2.fav && card2.amount == 1))
         return ctx.reply(user, `your query contains last copy of your favourite card(s). Please remove it from favourites and try again`, 'red')
 
-    const question = `Do you want to forge ${formatName(card1)}**(x${card1.amount})** and ${formatName(card2)}**(x${card2.amount})** using **${cost}** ${ctx.symbols.tomato}?
-        You will get **${vialres}** ${ctx.symbols.vial} and a **${card1.level} ${ctx.symbols.star} card**`
+    const question = `Do you want to forge ${formatName(card1)}**(x${card1.amount})** and ${formatName(card2)}**(x${card2.amount})** using **${numFmt(cost)}** ${ctx.symbols.tomato}?
+        You will get **${numFmt(vialres)}** ${ctx.symbols.vial} and a **${card1.level} ${ctx.symbols.star} card**`
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
         question,
@@ -120,7 +121,7 @@ cmd(['forge'], withMultiQuery(async (ctx, user, cards, parsedargs) => {
                     image: { url: newcard.url },
                     color: colors.blue,
                     description: `you got ${formatName(newcard)}!
-                        **${vialres}** ${ctx.symbols.vial} were added to your account
+                        **${numFmt(vialres)}** ${ctx.symbols.vial} were added to your account
                         ${usercard.amount > 1 ? `*You already have this card*` : ''}`
                 })
             } catch(e) {
@@ -155,7 +156,7 @@ cmd('liq', 'liquify', withCards(async (ctx, user, cards, parsedargs) => {
         return ctx.reply(user, `you are about to put up last copy of your favourite card for sale. 
             Please, use \`->fav remove ${card.name}\` to remove it from favourites first`, 'yellow')
 
-    const question = `Do you want to liquify ${formatName(card)} into **${vials}** ${ctx.symbols.vial}?
+    const question = `Do you want to liquify ${formatName(card)} into **${numFmt(vials)}** ${ctx.symbols.vial}?
         ${card.amount === 1? 'This is the last copy that you have' : `You will have **${card.amount - 1}** card(s) left`}`
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
@@ -171,8 +172,8 @@ cmd('liq', 'liquify', withCards(async (ctx, user, cards, parsedargs) => {
                 await completed(ctx, user, card)
                 await user.save()
 
-                ctx.reply(user, `card ${formatName(card)} was liquified. You got **${vials}** ${ctx.symbols.vial}
-                    You have **${user.vials}** ${ctx.symbols.vial}
+                ctx.reply(user, `card ${formatName(card)} was liquified. You got **${numFmt(vials)}** ${ctx.symbols.vial}
+                    You have **${numFmt(user.vials)}** ${ctx.symbols.vial}
                     You can use vials to draw **any 1-3 ${ctx.symbols.star}** card that you want. Use \`->draw\``)
             } catch(e) {
                 return ctx.reply(user, `an error occured while executing this command. 
@@ -223,7 +224,7 @@ cmd(['liq', 'all'], ['liquify', 'all'], withCards(async (ctx, user, cards, parse
             Please try again in **${msToTime(evalTime)}**.`, 'yellow')
     }
 
-    const question = `Do you want to liquify **${cards.length} card(s)** into **${vials}** ${ctx.symbols.vial}?
+    const question = `Do you want to liquify **${cards.length} card(s)** into **${numFmt(vials)}** ${ctx.symbols.vial}?
         To view cards that are going to be liquified, use \`->liq preview [query]\``
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
@@ -241,8 +242,8 @@ cmd(['liq', 'all'], ['liquify', 'all'], withCards(async (ctx, user, cards, parse
                 })
                 await user.save()
 
-                ctx.reply(user, `${cards.length} cards were liquified. You got **${vials}** ${ctx.symbols.vial}
-                    You have **${user.vials}** ${ctx.symbols.vial}
+                ctx.reply(user, `${cards.length} cards were liquified. You got **${numFmt(vials)}** ${ctx.symbols.vial}
+                    You have **${numFmt(user.vials)}** ${ctx.symbols.vial}
                     You can use vials to draw **any 1-3 ${ctx.symbols.star}** card that you want. Use \`->draw\``)
             } catch(e) {
                 return ctx.reply(user, `an error occured while executing this command. 
@@ -279,7 +280,7 @@ cmd(['liq', 'preview'], ['liquify', 'preview'], withCards(async (ctx, user, card
 
         return {
             cost,
-            cardname: `**${cost}** ${ctx.symbols.vial} - ${formatName(card)}`,
+            cardname: `**${numFmt(cost)}** ${ctx.symbols.vial} - ${formatName(card)}`,
         }
     })
 
@@ -294,7 +295,7 @@ cmd(['liq', 'preview'], ['liquify', 'preview'], withCards(async (ctx, user, card
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(resp.map(x => x.cardname), 10),
         embed: {
-            author: { name: `Liquify preview (total ${vials} ${ctx.symbols.vial})` },
+            author: { name: `Liquify preview (total ${numFmt(vials)} ${ctx.symbols.vial})` },
             description: '',
             color: colors.blue,
         }
@@ -328,11 +329,11 @@ cmd(['draw'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
 
     if(user.vials < vials)
         return ctx.reply(user, `you don't have enough vials to draw ${formatName(card)}
-            You need **${vials}** ${ctx.symbols.vial} (+**${extra}**) but you have **${user.vials}** ${ctx.symbols.vial}`, 'red')
+            You need **${numFmt(vials)}** ${ctx.symbols.vial} (+**${numFmt(extra)}**) but you have **${numFmt(user.vials)}** ${ctx.symbols.vial}`, 'red')
 
-    let question = `Do you want to draw ${formatName(card)} using **${vials}** ${ctx.symbols.vial}?`
+    let question = `Do you want to draw ${formatName(card)} using **${numFmt(vials)}** ${ctx.symbols.vial}?`
     if(amount > 0) {
-        question += `\n(+**${extra}** for your #${amount + 1} draw today)`
+        question += `\n(+**${numFmt(extra)}** for your #${amount + 1} draw today)`
     }
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
@@ -351,7 +352,7 @@ cmd(['draw'], withGlobalCards(async (ctx, user, cards, parsedargs) => {
                 image: { url: card.url },
                 color: colors.blue,
                 description: `you got ${formatName(card)}!
-                    You have **${user.vials}** ${ctx.symbols.vial} remaining`
+                    You have **${numFmt(user.vials)}** ${ctx.symbols.vial} remaining`
             })
         }
     })

--- a/commands/store.js
+++ b/commands/store.js
@@ -1,4 +1,5 @@
 const {cmd}     = require('../utils/cmd')
+const {numFmt}  = require('../utils/tools')
 const _         = require('lodash')
 const colors    = require('../utils/colors')
 
@@ -35,7 +36,7 @@ cmd('store', 'shop', async (ctx, user, cat) => {
                 To buy the item use \`->store buy [item id]\``
         }]}
 
-    const pages = ctx.pgn.getPages(items.map((x, i) => `${i + 1}. [${x.price} ${ctx.symbols.tomato}] \`${x.id}\` **${x.name}** (${x.desc})`), 5)
+    const pages = ctx.pgn.getPages(items.map((x, i) => `${i + 1}. [${numFmt(x.price)} ${ctx.symbols.tomato}] \`${x.id}\` **${x.name}** (${x.desc})`), 5)
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages, embed,
         buttons: ['back', 'forward'],
@@ -56,14 +57,14 @@ cmd(['store', 'buy'], ['shop', 'buy'], withItem(async (ctx, user, item, args) =>
         return ctx.reply(user, `you have to have at least \`${item.price}\` ${ctx.symbols.tomato} to buy this item`, 'red')
 
     return ctx.pgn.addConfirmation(user.discord_id, ctx.msg.channel.id, {
-        question: `Do you want to buy **${item.name} ${item.type}** for **${item.price}** ${ctx.symbols.tomato}?`,
+        question: `Do you want to buy **${item.name} ${item.type}** for **${numFmt(item.price)}** ${ctx.symbols.tomato}?`,
         force: ctx.globals.force,
         onConfirm: async (x) => {
             buyItem(ctx, user, item)
             user.exp -= item.price
             await user.save()
 
-            return ctx.reply(user, `you purchased **${item.name} ${item.type}** for **${item.price}** ${ctx.symbols.tomato}
+            return ctx.reply(user, `you purchased **${item.name} ${item.type}** for **${numFmt(item.price)}** ${ctx.symbols.tomato}
                 The item has been added to your inventory. See \`->inv info ${item.id}\` for details`, 'green')
         }
     })

--- a/commands/transaction.js
+++ b/commands/transaction.js
@@ -1,4 +1,5 @@
 const {cmd, pcmd}           = require('../utils/cmd')
+const {numFmt}              = require('../utils/tools')
 const {Transaction}         = require('../collections')
 const msToTime              = require('pretty-ms')
 const colors                = require('../utils/colors')
@@ -162,7 +163,7 @@ cmd(['trans', 'info'], async (ctx, user, arg1) => {
 
     const resp = []
     resp.push(`Cards: **${trs.cards.length}**`)
-    resp.push(`Price: **${trs.price}** ${ctx.symbols.tomato}`)
+    resp.push(`Price: **${numFmt(trs.price)}** ${ctx.symbols.tomato}`)
     resp.push(`From: **${trs.from}**`)
     resp.push(`To: **${trs.to}**`)
 

--- a/commands/user.js
+++ b/commands/user.js
@@ -265,7 +265,7 @@ cmd('cards', 'li', 'ls', 'list', withCards(async (ctx, user, cards, parsedargs) 
     const now = new Date()
     const cardstr = cards.map(c => {
         const isnew = c.obtained > (user.lastdaily || now)
-        return (isnew? '**[new]** ' : '') + formatName(c) + (c.amount > 1? ` (x${c.amount}) ` : ' ') + (c.rating? `[${c.rating}/10]` : '')
+        return (isnew? '**[new]** ' : '') + formatName(c) + (c.amount > 1? ` (x${c.amount}) ` : ' ') + (c.rating? `[${c.rating}/10]` : '') + (parsedargs.evalQuery? `${evalCardFast(ctx, c)}${ctx.symbols.tomato}`: '')
     })
 
     const evalTime = getQueueTime()
@@ -370,7 +370,7 @@ cmd('profile', async (ctx, user, ...args) => {
 }).access('dm')
 
 cmd('diff', async (ctx, user, ...args) => {
-    const newArgs = parseArgs(ctx, args)
+    const newArgs = parseArgs(ctx, args, user)
 
     if(!newArgs.ids[0])
         return ctx.qhelp(ctx, user, 'diff')
@@ -409,7 +409,7 @@ cmd('diff', async (ctx, user, ...args) => {
 })
 
 cmd(['diff', 'reverse'], ['diff', 'rev'], async (ctx, user, ...args) => {
-    const newArgs = parseArgs(ctx, args)
+    const newArgs = parseArgs(ctx, args, user)
 
     if(!newArgs.ids[0])
         return ctx.qhelp(ctx, user, 'diff')
@@ -449,7 +449,7 @@ cmd(['diff', 'reverse'], ['diff', 'rev'], async (ctx, user, ...args) => {
 })
 
 cmd('has', async (ctx, user, ...args) => {
-    const newArgs = parseArgs(ctx, args)
+    const newArgs = parseArgs(ctx, args, user)
 
     if(!newArgs.ids[0])
         return ctx.qhelp(ctx, user, 'has')

--- a/commands/user.js
+++ b/commands/user.js
@@ -7,6 +7,7 @@ const _                 = require('lodash')
 const {
     cap,
     claimCost,
+    numFmt,
     promoClaimCost,
     XPtoLEVEL,
 } = require('../utils/tools')
@@ -79,10 +80,10 @@ cmd('bal', 'balance', (ctx, user) => {
 
     const embed = {
         color: colors.green,
-        description: `you have **${Math.round(user.exp)}** ${ctx.symbols.tomato} and **${Math.round(user.vials)}** ${ctx.symbols.vial}
-            Your next claim will cost **${claimCost(user, 0, 1)}** ${ctx.symbols.tomato}
-            ${ctx.guild? `Next claim in current guild: **${claimCost(user, ctx.guild.tax, 1)}** ${ctx.symbols.tomato} (+${ctx.guild.tax * 100}% claim tax)`:''}
-            You can claim **${max - 1} cards** ${ctx.guild? `in current guild `:''}with your balance`
+        description: `you have **${numFmt(Math.round(user.exp))}** ${ctx.symbols.tomato} and **${numFmt(Math.round(user.vials))}** ${ctx.symbols.vial}
+            Your next claim will cost **${numFmt(claimCost(user, 0, 1))}** ${ctx.symbols.tomato}
+            ${ctx.guild? `Next claim in current guild: **${numFmt(claimCost(user, ctx.guild.tax, 1))}** ${ctx.symbols.tomato} (+${ctx.guild.tax * 100}% claim tax)`:''}
+            You can claim **${numFmt(max - 1)} cards** ${ctx.guild? `in current guild `:''}with your balance`
     }
 
     if(promo) {
@@ -92,9 +93,9 @@ cmd('bal', 'balance', (ctx, user) => {
 
         embed.fields = [{
             name: `Promo balance`,
-            value: `You have **${Math.round(user.promoexp)}** ${promo.currency}
-                Your next claim will cost **${promoClaimCost(user, 1)}** ${promo.currency}
-                You can claim **${max - 1} ${promo.name} cards** with your balance`
+            value: `You have **${numFmt(Math.round(user.promoexp))}** ${promo.currency}
+                Your next claim will cost **${numFmt(promoClaimCost(user, 1))}** ${promo.currency}
+                You can claim **${numFmt(max - 1)} ${promo.name} cards** with your balance`
         }]
     }
 
@@ -251,8 +252,8 @@ cmd('daily', async (ctx, user) => {
         })
 
         return ctx.reply(user, {
-            description: `you received daily **${amount}** ${ctx.symbols.tomato} ${promo? `and **${promoAmount}** ${promo.currency}`: ""}
-                You now have **${Math.round(user.exp)}** ${ctx.symbols.tomato} ${promo? `and **${user.promoexp}** ${promo.currency}`: ""}`,
+            description: `you received daily **${numFmt(amount)}** ${ctx.symbols.tomato} ${promo? `and **${numFmt(promoAmount)}** ${promo.currency}`: ""}
+                You now have **${numFmt(Math.round(user.exp))}** ${ctx.symbols.tomato} ${promo? `and **${numFmt(user.promoexp)}** ${promo.currency}`: ""}`,
             color: colors.green,
             fields
         })
@@ -265,7 +266,7 @@ cmd('cards', 'li', 'ls', 'list', withCards(async (ctx, user, cards, parsedargs) 
     const now = new Date()
     const cardstr = cards.map(c => {
         const isnew = c.obtained > (user.lastdaily || now)
-        return (isnew? '**[new]** ' : '') + formatName(c) + (c.amount > 1? ` (x${c.amount}) ` : ' ') + (c.rating? `[${c.rating}/10]` : '') + (parsedargs.evalQuery? `${evalCardFast(ctx, c)}${ctx.symbols.tomato}`: '')
+        return (isnew? '**[new]** ' : '') + formatName(c) + (c.amount > 1? ` (x${numFmt(c.amount)}) ` : ' ') + (c.rating? `[${c.rating}/10]` : '') + (parsedargs.evalQuery? `${evalCardFast(ctx, c)}${ctx.symbols.tomato}`: '')
     })
 
     const evalTime = getQueueTime()
@@ -278,7 +279,7 @@ cmd('cards', 'li', 'ls', 'list', withCards(async (ctx, user, cards, parsedargs) 
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(cardstr, 15),
-        embed: { author: { name: `${user.username}, your cards (${cards.length} results)` } }
+        embed: { author: { name: `${user.username}, your cards (${numFmt(cards.length)} results)` } }
     })
 })).access('dm')
 
@@ -287,12 +288,12 @@ cmd('favs', withCards(async (ctx, user, cards, parsedargs) => {
     cards = cards.filter(x => x.fav)
     const cardstr = cards.map(c => {
         const isnew = c.obtained > (user.lastdaily || now)
-        return (isnew? '**[new]** ' : '') + formatName(c) + (c.amount > 1? ` (x${c.amount}) ` : ' ') + (c.rating? `[${c.rating}/10]` : '')
+        return (isnew? '**[new]** ' : '') + formatName(c) + (c.amount > 1? ` (x${numFmt(c.amount)}) ` : ' ') + (c.rating? `[${c.rating}/10]` : '')
     })
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(cardstr, 15),
-        embed: { author: { name: `${user.username}, your cards (${cards.length} results)` } }
+        embed: { author: { name: `${user.username}, your cards (${numFmt(cards.length)} results)` } }
     })
 })).access('dm')
 
@@ -326,12 +327,12 @@ cmd('profile', async (ctx, user, ...args) => {
     })
     const resp = []
     resp.push(`Level: **${XPtoLEVEL(user.xp)}**`)
-    resp.push(`Cards: **${user.cards.length}** | Stars: **${cards.map(x => x.level).reduce((a, b) => a + b, 0)}**`)
+    resp.push(`Cards: **${numFmt(user.cards.length)}** | Stars: **${numFmt(cards.map(x => x.level).reduce((a, b) => a + b, 0))}**`)
 
     if (pargs.ids.length > 0 && !isNaN(price)) {
-        resp.push(`Cards Worth: **${price.toLocaleString('en-US')}** ${ctx.symbols.tomato} or **${vials.toLocaleString('en-US')} ${ctx.symbols.vial}**`)
+        resp.push(`Cards Worth: **${numFmt(price)}** ${ctx.symbols.tomato} or **${numFmt(vials)} ${ctx.symbols.vial}**`)
     } else if (!isNaN(price)) {
-        resp.push(`Net Worth: **${(price + user.exp).toLocaleString('en-US')}** ${ctx.symbols.tomato} or **${(vials + user.vials).toLocaleString('en-US')} ${ctx.symbols.vial}**`)
+        resp.push(`Net Worth: **${numFmt(price + user.exp)}** ${ctx.symbols.tomato} or **${numFmt(vials + user.vials)} ${ctx.symbols.vial}**`)
     } else {
         const evalTime = getQueueTime()
         resp.push(`Worth: **Calculating , try again in ${msToTime(evalTime)}**`)
@@ -340,10 +341,10 @@ cmd('profile', async (ctx, user, ...args) => {
     resp.push(`In game since: **${stampString}** (${msToTime(new Date() - stamp, {compact: true})})`)
 
     if(completedSum > 0) {
-        resp.push(`Completed collections: **${user.completedcols.length}**`)
+        resp.push(`Completed collections: **${numFmt(user.completedcols.length)}**`)
     }
     if(cloutsum > 0) {
-        resp.push(`Overall clout: **${cloutsum}**`)
+        resp.push(`Overall clout: **${numFmt(cloutsum)}**`)
     }
 
     if(ctx.guild) {
@@ -404,7 +405,7 @@ cmd('diff', async (ctx, user, ...args) => {
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(diff.map(x => `${formatName(x)} ${x.amount > 1? `(x${x.amount})`: ''} ${x.rating? `[${x.rating}/10]` : ''}`), 15),
-        embed: { author: { name: `${user.username}, unique cards FROM ${otherUser.username} (${diff.length} results)` } }
+        embed: { author: { name: `${user.username}, unique cards FROM ${otherUser.username} (${numFmt(diff.length)} results)` } }
     })
 })
 
@@ -444,7 +445,7 @@ cmd(['diff', 'reverse'], ['diff', 'rev'], async (ctx, user, ...args) => {
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(diff.map(x => `${formatName(x)} ${x.amount > 1? `(x${x.amount})`: ''} ${x.rating? `[${x.rating}/10]` : ''}`), 15),
-        embed: { author: { name: `${user.username}, unique cards FOR ${otherUser.username} (${diff.length} results)` } }
+        embed: { author: { name: `${user.username}, unique cards FOR ${otherUser.username} (${numFmt(diff.length)} results)` } }
     })
 })
 
@@ -483,7 +484,7 @@ cmd('miss', withGlobalCards(async (ctx, user, cards, parsedargs) => {
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
         pages: ctx.pgn.getPages(diff.map(x => formatName(x)), 15),
-        embed: { author: { name: `${user.username}, cards that you don't have (${diff.length} results)` } }
+        embed: { author: { name: `${user.username}, cards that you don't have (${numFmt(diff.length)} results)` } }
     })
 }))
 

--- a/index.js
+++ b/index.js
@@ -272,6 +272,7 @@ module.exports.create = async ({
                 && !cntnt.includes(setbotmsg)
                 && !cntnt.includes(setreportmsg)
                 && !cntnt.startsWith('sum')
+                && !cntnt.startsWith('pat')
                 && !curguild.botchannels.some(x => x === msg.channel.id)) {
 
                 /* skip cooldown guilds */
@@ -295,15 +296,14 @@ module.exports.create = async ({
 
                 return
             }
-
             /* fill in additional context data */
             const isolatedCtx = Object.assign({}, ctx, {
                 msg, /* current icoming msg object */
                 reply, /* quick reply function to the channel */
                 globals: {}, /* global parameters */
                 discord_guild: msg.channel.guild,  /* current discord guild */
+                prefix: curprefix, /* current prefix */
             })
-
             /* add user to cooldown q */
             userq.push({id: msg.author.id, expires: asdate.add(new Date(), 5, 'seconds')});
 

--- a/modules/auction.js
+++ b/modules/auction.js
@@ -1,7 +1,11 @@
 const {Auction, AuditAucSell}         = require('../collections')
 const {evalCard}                      = require("../modules/eval");
-const {generateNextId}                = require('../utils/tools')
 const {fetchOnly}                     = require('./user')
+
+const {
+    generateNextId,
+    numFmt,
+} = require('../utils/tools')
 
 const {
     completed,
@@ -125,7 +129,7 @@ const bid_auc = async (ctx, user, auc, bid, add = false) => {
         const { aucoutbid } = lastBidder.prefs.notifications
         if(aucoutbid && lastBidder.discord_id != user.discord_id) {
             await ctx.direct(lastBidder, `Another player has outbid you on card ${formatName(ctx.cards[auc.card])}
-                To remain in the auction, try bidding higher than ${auc.price} ${ctx.symbols.tomato}
+                To remain in the auction, try bidding higher than ${numFmt(auc.price)} ${ctx.symbols.tomato}
                 Use \`->auc bid ${auc.id} [new bid]\`
                 This auction will end in **${formatAucTime(auc.expires)}**`, 'yellow')
         }
@@ -133,21 +137,21 @@ const bid_auc = async (ctx, user, auc, bid, add = false) => {
         const { aucnewbid } = author.prefs.notifications
         if(aucnewbid) {
             await ctx.direct(author, `your auction \`${auc.id}\` for card 
-                ${formatName(ctx.cards[auc.card])} got a new bid. New listed price: **${auc.price} ${ctx.symbols.tomato}**.`, 'blue')
+                ${formatName(ctx.cards[auc.card])} got a new bid. New listed price: **${numFmt(auc.price)} ${ctx.symbols.tomato}**.`, 'blue')
         }
     } else if (!add) {
         const { aucbidme } = author.prefs.notifications
         if(aucbidme) {
             await ctx.direct(author, `a player has bid on your auction \`${auc.id}\` for card 
-                ${formatName(ctx.cards[auc.card])} with minimum ${auc.price} ${ctx.symbols.tomato}!`, 'green')
+                ${formatName(ctx.cards[auc.card])} with minimum ${numFmt(auc.price)} ${ctx.symbols.tomato}!`, 'green')
         }
     }
 
     if (add)
-        return ctx.reply(user, `you successfully increased your bid on auction \`${auc.id}\` to **${bid}** ${ctx.symbols.tomato}!
+        return ctx.reply(user, `you successfully increased your bid on auction \`${auc.id}\` to **${numFmt(bid)}** ${ctx.symbols.tomato}!
                                 You can add to your bid **${bidsLeft}** more times!`)
     else
-        return ctx.reply(user, `you successfully bid on auction \`${auc.id}\` with **${bid}** ${ctx.symbols.tomato}!`)
+        return ctx.reply(user, `you successfully bid on auction \`${auc.id}\` with **${numFmt(bid)}** ${ctx.symbols.tomato}!`)
 }
 
 const finish_aucs = async (ctx, now) => {
@@ -170,12 +174,12 @@ const finish_aucs = async (ctx, now) => {
         await author.save()
 
         if(author.prefs.notifications.aucend) {
-            await ctx.direct(author, `you sold ${formatName(ctx.cards[auc.card])} on auction \`${auc.id}\` for **${auc.price}** ${ctx.symbols.tomato}`)
+            await ctx.direct(author, `you sold ${formatName(ctx.cards[auc.card])} on auction \`${auc.id}\` for **${numFmt(auc.price)}** ${ctx.symbols.tomato}`)
         }
 
         await ctx.direct(lastBidder, `you won auction \`${auc.id}\` for card ${formatName(ctx.cards[auc.card])}!
-            You ended up paying **${Math.round(auc.price)}** ${ctx.symbols.tomato} and got **${Math.round(auc.highbid - auc.price)}** ${ctx.symbols.tomato} back.
-            ${tback > 0? `You got additional **${tback}** ${ctx.symbols.tomato} from your equipped effect` : ''}`)
+            You ended up paying **${numFmt(Math.round(auc.price))}** ${ctx.symbols.tomato} and got **${numFmt(Math.round(auc.highbid - auc.price))}** ${ctx.symbols.tomato} back.
+            ${tback > 0? `You got additional **${numFmt(tback)}** ${ctx.symbols.tomato} from your equipped effect` : ''}`)
 
         const aucCard = ctx.cards[auc.card]
         const eval = await evalCard(ctx, aucCard)
@@ -220,7 +224,7 @@ const paginate_auclist = (ctx, user, list) => {
             char = ctx.symbols.auc_sod
         }
 
-        pages[Math.floor(i/10)] += `${char} [${diffstr}] \`${auc.id}\` [${auc.price}${ctx.symbols.tomato}] ${formatName(ctx.cards[auc.card])}\n`
+        pages[Math.floor(i/10)] += `${char} [${diffstr}] \`${auc.id}\` [${numFmt(auc.price)}${ctx.symbols.tomato}] ${formatName(ctx.cards[auc.card])}\n`
     })
 
     return pages;
@@ -235,14 +239,14 @@ const format_auc = async(ctx, auc, author, doeval = true) => {
 
     const resp = []
     resp.push(`Seller: **${author.username}**`)
-    resp.push(`Price: **${auc.price}** ${ctx.symbols.tomato}`)
+    resp.push(`Price: **${numFmt(auc.price)}** ${ctx.symbols.tomato}`)
     resp.push(`Card: ${formatName(card)}`)
 
     if(doeval)
-        resp.push(`Card value: **${await evalCard(ctx, card)}** ${ctx.symbols.tomato}`)
+        resp.push(`Card value: **${numFmt(await evalCard(ctx, card))}** ${ctx.symbols.tomato}`)
 
     if(auc.finished) {
-        resp.push(`Winning bid: **${auc.highbid}**${ctx.symbols.tomato}`)
+        resp.push(`Winning bid: **${numFmt(auc.highbid)}**${ctx.symbols.tomato}`)
         resp.push(`**This auction has finished**`)
     } else {
         resp.push(`Expires in **${timediff}**`)

--- a/modules/auction.js
+++ b/modules/auction.js
@@ -127,7 +127,7 @@ const bid_auc = async (ctx, user, auc, bid, add = false) => {
             await ctx.direct(lastBidder, `Another player has outbid you on card ${formatName(ctx.cards[auc.card])}
                 To remain in the auction, try bidding higher than ${auc.price} ${ctx.symbols.tomato}
                 Use \`->auc bid ${auc.id} [new bid]\`
-                This auction will end in **${diff > 60000? msToTime(diff) : '<1m'}**`, 'yellow')
+                This auction will end in **${formatAucTime(auc.expires)}**`, 'yellow')
         }
 
         const { aucnewbid } = author.prefs.notifications
@@ -166,7 +166,17 @@ const finish_aucs = async (ctx, now) => {
         lastBidder.exp += (auc.highbid - auc.price) + tback
         author.exp += auc.price
         addUserCard(lastBidder, auc.card)
-        //Audit Logic Start
+        await lastBidder.save()
+        await author.save()
+
+        if(author.prefs.notifications.aucend) {
+            await ctx.direct(author, `you sold ${formatName(ctx.cards[auc.card])} on auction \`${auc.id}\` for **${auc.price}** ${ctx.symbols.tomato}`)
+        }
+
+        await ctx.direct(lastBidder, `you won auction \`${auc.id}\` for card ${formatName(ctx.cards[auc.card])}!
+            You ended up paying **${Math.round(auc.price)}** ${ctx.symbols.tomato} and got **${Math.round(auc.highbid - auc.price)}** ${ctx.symbols.tomato} back.
+            ${tback > 0? `You got additional **${tback}** ${ctx.symbols.tomato} from your equipped effect` : ''}`)
+
         const aucCard = ctx.cards[auc.card]
         const eval = await evalCard(ctx, aucCard)
         await eval_fraud_check(ctx, auc, eval, aucCard)
@@ -174,20 +184,11 @@ const finish_aucs = async (ctx, now) => {
             await audit_auc_stats(ctx, author, true)
         else
             await AuditAucSell.findOneAndUpdate({ user: author.discord_id}, {$inc: {sold: 1}})
-        // End audit logic
-        await completed(ctx, lastBidder, aucCard)
-        await lastBidder.save()
-        await author.save()
-        await from_auc(auc, author, lastBidder)
-        await aucEvalChecks(ctx, auc)
 
-        if(author.prefs.notifications.aucend) {
-            await ctx.direct(author, `you sold ${formatName(ctx.cards[auc.card])} on auction \`${auc.id}\` for **${auc.price}** ${ctx.symbols.tomato}`)
-        }
-        
-        return ctx.direct(lastBidder, `you won auction \`${auc.id}\` for card ${formatName(ctx.cards[auc.card])}!
-            You ended up paying **${Math.round(auc.price)}** ${ctx.symbols.tomato} and got **${Math.round(auc.highbid - auc.price)}** ${ctx.symbols.tomato} back.
-            ${tback > 0? `You got additional **${tback}** ${ctx.symbols.tomato} from your equipped effect` : ''}`)
+        await completed(ctx, lastBidder, aucCard)
+        await aucEvalChecks(ctx, auc)
+        await from_auc(auc, author, lastBidder)
+
     } else {
         if(!findSell)
             await audit_auc_stats(ctx, author, false)
@@ -209,7 +210,7 @@ const paginate_auclist = (ctx, user, list) => {
 
         const msdiff = auc.expires - new Date()
         const timediff = msToTime(msdiff, {compact: true})
-        const diffstr = msdiff > aucHide? timediff : '<5m'
+        const diffstr = formatAucTime(auc.expires, true)
         let char = ctx.symbols.auc_wss
 
         if(auc.author === user.discord_id) {
@@ -228,7 +229,7 @@ const paginate_auclist = (ctx, user, list) => {
 const format_auc = async(ctx, auc, author, doeval = true) => {
     const card = ctx.cards[auc.card]
     const msdiff = auc.expires - new Date()
-    const timediff = msToTime(msdiff)
+    const timediff = formatAucTime(auc.expires)
 
     console.log(msdiff)
 
@@ -244,10 +245,29 @@ const format_auc = async(ctx, auc, author, doeval = true) => {
         resp.push(`Winning bid: **${auc.highbid}**${ctx.symbols.tomato}`)
         resp.push(`**This auction has finished**`)
     } else {
-        resp.push(`Expires in **${msdiff > aucHide? timediff : '<5m'}**`)
+        resp.push(`Expires in **${timediff}**`)
     }
 
     return resp.join('\n')
+}
+
+const formatAucTime = (time, compact = false) => {
+    const timeToEndMS = time - new Date()
+
+    if (timeToEndMS <= 0)
+        return `0s`
+
+    const hours = Math.floor((timeToEndMS / (1000 * 60)) / 60)
+    const minutes = Math.floor((timeToEndMS / (1000 * 60)) % 60)
+
+    if (hours === 0 && minutes <= 5)
+        return `<5m`
+
+    if (compact) {
+        return `~${hours <= 0? `~${minutes}m` : `${minutes > 45? hours + 1: minutes < 15? hours - 1: `${hours}.5`}h`}`
+    }
+
+    return `${hours <= 0? '': `${hours}h`} ${minutes}m`
 }
 
 const unlock = () => {

--- a/modules/audit.js
+++ b/modules/audit.js
@@ -8,6 +8,7 @@ const {byAlias}          = require('./collection')
 const {
     generateNextId,
     tryGetUserID,
+    numFmt,
 } = require('../utils/tools')
 
 const {
@@ -158,7 +159,7 @@ const format_overPrice = (ctx, user, auc) => {
     let col
     if (!isNaN(auc.card[0]))
         col = byAlias(ctx, ctx.cards[auc.card[0]].col)[0]
-    resp += `\`${auc.audit_id}\` | \`${auc.id}\` | **${auc.price}**${ctx.symbols.tomato} | ${auc.price_over.toLocaleString('en-us', {maximumFractionDigits: 2})} | ${auc.eval} | ${col? col.promo : 'false'} `
+    resp += `\`${auc.audit_id}\` | \`${auc.id}\` | **${numFmt(auc.price)}**${ctx.symbols.tomato} | ${auc.price_over.toLocaleString('en-us', {maximumFractionDigits: 2})} | ${numFmt(auc.eval)} | ${col? col.promo : 'false'} `
 
     return resp;
 }
@@ -169,7 +170,7 @@ const format_rebuys = (ctx, user, auc) => {
     if (!isNaN(auc.card[0]))
         col = byAlias(ctx, ctx.cards[auc.card[0]].col)[0]
 
-    resp += `\`${auc.audit_id}\` | \`${auc.id}\` | **${auc.price}**${ctx.symbols.tomato} | ${auc.transid} | **${auc.transprice}**${ctx.symbols.tomato} | ${col? col.promo : 'false'}`
+    resp += `\`${auc.audit_id}\` | \`${auc.id}\` | **${numFmt(auc.price)}**${ctx.symbols.tomato} | ${auc.transid} | **${numFmt(auc.transprice)}**${ctx.symbols.tomato} | ${col? col.promo : 'false'}`
 
     return resp;
 }
@@ -184,7 +185,7 @@ const formatGuildTrsList = (ctx, user, gtrans) => {
 
 const formatAucBidList = (ctx, user, bids) => {
     let resp = ""
-    resp += `${bids.bid}${ctx.symbols.tomato}, \`${bids.user}\`, ${dateFormat(bids.time, "yyyy-mm-dd HH:MM:ss")}`
+    resp += `${numFmt(bids.bid)}${ctx.symbols.tomato}, \`${bids.user}\`, ${dateFormat(bids.time, "yyyy-mm-dd HH:MM:ss")}`
     return resp;
 }
 

--- a/modules/card.js
+++ b/modules/card.js
@@ -1,4 +1,5 @@
-const asdate = require('add-subtract-date')
+const asdate    = require('add-subtract-date')
+const {firstBy} = require('thenby')
 
 const {
     cap,
@@ -45,14 +46,15 @@ const formatName = (x) => {
     //return `[${new Array(x.level + 1).join('★')}]${x.fav? ' `❤` ' : ' '}[${cap(x.name.replace(/_/g, ' '))}](${x.shorturl}) \`[${x.col}]\``
 }
 
-const parseArgs = (ctx, args, lastdaily) => {
-    lastdaily = lastdaily || asdate.subtract(new Date(), 1, 'day')
-    
+const parseArgs = (ctx, args, user) => {
+    const lastdaily = user? user.lastdaily: asdate.subtract(new Date(), 1, 'day')
+
     const cols = [], levels = [], keywords = []
     const anticols = [], antilevels = []
+    let sort
     const q = { 
         ids: [], 
-        sort: (a, b) => b.level - a.level,
+        sort: null,
         filters: [],
         tags: [],
         antitags: [],
@@ -73,34 +75,32 @@ const parseArgs = (ctx, args, lastdaily) => {
             q.lastcard = true
 
         } else if((x[0] === '<' || x[0] === '>' || x[0] === '=' || x[0] === '\\') && x[1] != '@') {
-            switch(x) {
-                case '<date': q.sort = (a, b) => a.obtained - b.obtained; q.userQuery = true; break
-                case '>date': q.sort = (a, b) => b.obtained - a.obtained; q.userQuery = true; break
-                case '<amount': q.sort = (a, b) => a.amount - b.amount; break
-                case '>amount': q.sort = (a, b) => b.amount - a.amount; break
-                case '<name': q.sort = (a, b) => nameSort(a, b); break
-                case '>name': q.sort = (a, b) => nameSort(a, b) * -1; break
-                case '<star': q.sort = (a, b) => a.level - b.level; break
-                case '>star': q.sort = (a, b) => b.level - a.level; break
-                case '<col': q.sort = (a, b) => nameSort(a , b, "col"); break
-                case '>col': q.sort = (a, b) => nameSort(a , b, "col") * -1; break
-                case '<eval': 
-                    q.sort = (a, b) => evalCardFast(ctx, a) - evalCardFast(ctx, b)
-                    q.evalQuery = true
-                    break
-                case '>eval': 
-                    q.sort = (a, b) => evalCardFast(ctx, b) - evalCardFast(ctx, a)
-                    q.evalQuery = true
-                    break
-                case '<rating': 
-                    q.sort = (a, b) => (a.rating || 0) - (b.rating || 0)
+            const lt = x[0] === '<'
+            switch(substr) {
+                case 'date':
+                    sort = sortBuilder(ctx, sort,(a, b) => a.obtained - b.obtained, lt)
                     q.userQuery = true
                     break
-                case '>rating': 
-                    q.sort = (a, b) => (b.rating || 0) - (a.rating || 0)
+                case 'amount':
+                    sort = sortBuilder(ctx, sort,(a, b) => a.amount - b.amount, lt)
+                    break
+                case 'name':
+                    sort = sortBuilder(ctx, sort,(a, b) => nameSort(a, b) , lt)
+                    break
+                case 'star':
+                    sort = sortBuilder(ctx, sort,(a, b) => a.level - b.level , lt)
+                    break
+                case 'col':
+                    sort = sortBuilder(ctx, sort,(a, b) => nameSort(a, b, "col") , lt)
+                    break
+                case 'eval':
+                    sort = sortBuilder(ctx, sort,(a, b) => evalSort(ctx, a, b) , lt)
+                    q.evalQuery = true
+                    break
+                case 'rating':
+                    sort = sortBuilder(ctx, sort,(a, b) => (a.rating || 0) - (b.rating || 0), lt)
                     q.userQuery = true
                     break
-                
                 default: {
                     const eq = x[1] === '='
                     eq? substr = x.substr(2): substr
@@ -127,7 +127,8 @@ const parseArgs = (ctx, args, lastdaily) => {
                     case 'multi': q.filters.push(c => m? c.amount > 1 : c.amount === 1); q.userQuery = true; break
                     case 'fav': q.filters.push(c => m? c.fav : !c.fav); m? q.fav = true: q.fav; q.userQuery = true; break
                     case 'new': q.filters.push(c => m? c.obtained > lastdaily : c.obtained <= lastdaily); q.userQuery = true; break
-                    case 'rated': q.filters.push(c => m? c.rating: !c.rating); break
+                    case 'rated': q.filters.push(c => m? c.rating: !c.rating); q.userQuery = true; break
+                    case 'wish': q.filters.push(c => m? user.wishlist.includes(c.id): !user.wishlist.includes(c.id)); q.userQuery = true; break
                     case 'promo': const mcol = bestColMatchMulti(ctx, substr); m? mcol.map(x=> cols.push(x.id)): mcol.map(x=> anticols.push(x.id)); break
                     case 'diff': q.diff = m; break
                     case 'miss': q.diff = m; break
@@ -166,8 +167,25 @@ const parseArgs = (ctx, args, lastdaily) => {
     q.isEmpty = (usetag = true) => {
         return !q.ids[0] && !q.lastcard && !q.filters[0] && !((q.tags[0] || q.antitags[0]) && usetag)
     }
+    if (!sort)
+        q.sort = firstBy((a, b) => b.level - a.level).thenBy("name")
+    else
+        q.sort = sort
 
     return q
+}
+
+const evalSort = (ctx, a, b) => {
+    if(evalCardFast(ctx, a) > evalCardFast(ctx, b))return 1
+    if(evalCardFast(ctx, a) < evalCardFast(ctx, b))return -1
+    return 0
+}
+
+const sortBuilder = (ctx, sort, sortby, lt) => {
+    if (!sort)
+        return firstBy(sortby, {direction: lt? "asc": "desc"})
+    else
+        return sort.thenBy(sortby, {direction: lt? "asc": "desc"})
 }
 
 const filter = (cards, query) => {
@@ -219,7 +237,7 @@ const withCards = (callback) => async (ctx, user, ...args) => {
     if(user.cards.length == 0)
         return ctx.reply(user, `you don't have any cards. Get some using \`${ctx.prefix}claim\``, 'red')
 
-    const parsedargs = parseArgs(ctx, args, user.lastdaily)
+    const parsedargs = parseArgs(ctx, args, user)
     const map = mapUserCards(ctx, user)
     let cards = filter(map, parsedargs)
 
@@ -255,7 +273,7 @@ const withCards = (callback) => async (ctx, user, ...args) => {
  * @return {Promise}
  */
 const withGlobalCards = (callback) => async(ctx, user, ...args) => {
-    const parsedargs = parseArgs(ctx, args)
+    const parsedargs = parseArgs(ctx, args, user)
     let allcards
     if(parsedargs.userQuery)
         allcards = mapUserCards(ctx, user)
@@ -300,7 +318,7 @@ const withGlobalCards = (callback) => async(ctx, user, ...args) => {
 const withMultiQuery = (callback) => async (ctx, user, ...args) => {
     const argsplit = args.join(' ').split(',').map(x => x.trim())
     const parsedargs = [], cards = []
-    argsplit.map(x => parsedargs.push(parseArgs(ctx, x.split(' '), user.lastdaily)))
+    argsplit.map(x => parsedargs.push(parseArgs(ctx, x.split(' '), user)))
 
     if(!parsedargs[0] || parsedargs[0].isEmpty())
         return ctx.reply(user, `please specify at least one card query`, 'red')

--- a/modules/card.js
+++ b/modules/card.js
@@ -128,7 +128,7 @@ const parseArgs = (ctx, args, user) => {
                     case 'fav': q.filters.push(c => m? c.fav : !c.fav); m? q.fav = true: q.fav; q.userQuery = true; break
                     case 'new': q.filters.push(c => m? c.obtained > lastdaily : c.obtained <= lastdaily); q.userQuery = true; break
                     case 'rated': q.filters.push(c => m? c.rating: !c.rating); q.userQuery = true; break
-                    case 'wish': q.filters.push(c => m? user.wishlist.includes(c.id): !user.wishlist.includes(c.id)); q.userQuery = true; break
+                    case 'wish': q.filters.push(c => m? user.wishlist.includes(c.id): !user.wishlist.includes(c.id)); break
                     case 'promo': const mcol = bestColMatchMulti(ctx, substr); m? mcol.map(x=> cols.push(x.id)): mcol.map(x=> anticols.push(x.id)); break
                     case 'diff': q.diff = m; break
                     case 'miss': q.diff = m; break

--- a/modules/eval.js
+++ b/modules/eval.js
@@ -6,6 +6,9 @@ const cardMod   = require('./card');
 const colors    = require('../utils/colors')
 
 const {
+    numFmt
+} = require('../utils/tools')
+const {
     fetchInfo,
 } = require('./meta')
 
@@ -222,12 +225,12 @@ const aucEvalChecks = async (ctx, auc, success = true) => {
                 },
                 {
                     name: "Old Eval",
-                    value: `${lastEval}`,
+                    value: `${numFmt(lastEval)}`,
                     inline: true
                 },
                 {
                     name: "New Eval",
-                    value: `${newEval}`,
+                    value: `${numFmt(newEval)}`,
                     inline: true
                 },
                 {

--- a/modules/guild.js
+++ b/modules/guild.js
@@ -37,7 +37,6 @@ const fetchOrCreate = async (ctx, user, discord_guild) => {
         guild.botchannels = [ctx.msg.channel.id]
         guild.reportchannel = ctx.msg.channel.id
         guild.nextcheck = asdate.add(new Date(), 20, 'hours')
-        guild.prefix = "->"
 
         await guild.save()
         await ctx.reply(user, `new guild added. This channel was marked as bot and report channel.

--- a/modules/guild.js
+++ b/modules/guild.js
@@ -11,6 +11,10 @@ const {
     check_effect,
 } = require('./effect')
 
+const {
+    numFmt
+} = require('../utils/tools')
+
 const m_hero = require('./hero')
 
 let cache = []
@@ -122,12 +126,12 @@ const bill_guilds = async (ctx, now) => {
     if(ratio == Infinity)
         ratio = 0
 
-    report.push(`Maintenance cost: **${total}** ${ctx.symbols.tomato}`)
+    report.push(`Maintenance cost: **${numFmt(total)}** ${ctx.symbols.tomato}`)
     if(guild.discount > 0) {
-        report.push(`Applied discount: **${guild.discount * 100}%** (${discount} ${ctx.symbols.tomato})`)
+        report.push(`Applied discount: **${guild.discount * 100}%** (${numFmt(discount)} ${ctx.symbols.tomato})`)
     }
 
-    report.push(`Remaining guild balance: **${guild.balance}** ${ctx.symbols.tomato}`)
+    report.push(`Remaining guild balance: **${numFmt(guild.balance)}** ${ctx.symbols.tomato}`)
 
     const past = asdate.subtract(new Date(), 7, 'days')
     const activeUsers = await User.countDocuments({ 
@@ -219,8 +223,8 @@ const getBuildingInfo = (ctx, user, args) => {
         description: item.fulldesc,
         fields: item.levels.map((x, i) => ({
             name: `Level ${i + 1}`, 
-            value: `Price: **${x.price}** ${ctx.symbols.tomato}
-                Maintenance: **${x.maintenance}** ${ctx.symbols.tomato}/day
+            value: `Price: **${numFmt(x.price)}** ${ctx.symbols.tomato}
+                Maintenance: **${numFmt(x.maintenance)}** ${ctx.symbols.tomato}/day
                 Required guild level: **${x.level}**
                 > ${x.desc.replace(/{currency}/gi, ctx.symbols.tomato)}`
     }))}

--- a/modules/guild.js
+++ b/modules/guild.js
@@ -33,6 +33,7 @@ const fetchOrCreate = async (ctx, user, discord_guild) => {
         guild.botchannels = [ctx.msg.channel.id]
         guild.reportchannel = ctx.msg.channel.id
         guild.nextcheck = asdate.add(new Date(), 20, 'hours')
+        guild.prefix = "->"
 
         await guild.save()
         await ctx.reply(user, `new guild added. This channel was marked as bot and report channel.

--- a/modules/hero.js
+++ b/modules/hero.js
@@ -4,9 +4,12 @@ const Guild         = require('../collections/guild')
 
 const {fetchOnly}   = require('./user')
 const m_guild       = require('./guild')
-const {XPtoLEVEL}   = require('../utils/tools')
 const _             = require('lodash')
 const colors        = require('../utils/colors')
+const {
+    XPtoLEVEL,
+    numFmt,
+}   = require('../utils/tools')
 
 let hcache = []
 
@@ -67,7 +70,7 @@ const getInfo = async (ctx, user, id) => {
     hero.followers = await User.countDocuments({ hero: id })
     return { 
         author: { name: hero.name },
-        description: `Level **${XPtoLEVEL(hero.xp)}**\nFollowers: **${hero.followers}**\nID: ${hero.id}`,
+        description: `Level **${numFmt(XPtoLEVEL(hero.xp))}**\nFollowers: **${numFmt(hero.followers)}**\nID: ${hero.id}`,
         image: { url: _.sample(hero.pictures) },
         color: colors.blue
     }

--- a/modules/item.js
+++ b/modules/item.js
@@ -1,7 +1,11 @@
-const {XPtoLEVEL}   = require('../utils/tools')
 const _             = require('lodash')
 const colors        = require('../utils/colors')
 const asdate        = require('add-subtract-date')
+
+const {
+    XPtoLEVEL,
+    numFmt,
+} = require('../utils/tools')
 
 const {
     getGuildUser,
@@ -188,8 +192,8 @@ const infos = {
         description: item.fulldesc,
         fields: item.levels.map((x, i) => ({
             name: `Level ${i + 1}`, 
-            value: `Price: **${x.price}** ${ctx.symbols.tomato}
-                Maintenance: **${x.maintenance}** ${ctx.symbols.tomato}/day
+            value: `Price: **${numFmt(x.price)}** ${ctx.symbols.tomato}
+                Maintenance: **${numFmt(x.maintenance)}** ${ctx.symbols.tomato}/day
                 Required guild level: **${x.level}**
                 > ${x.desc.replace(/{currency}/gi, ctx.symbols.tomato)}`
         }))
@@ -222,9 +226,9 @@ const infos = {
         ]
 
         if(effect.passive) {
-            fields.push({ name: `Lasts`, value: `**${item.lasts}** days after being crafted` })
+            fields.push({ name: `Lasts`, value: `**${numFmt(item.lasts)}** days after being crafted` })
         } else {
-            fields.push({ name: `Can be used`, value: `**${item.lasts}** times` })
+            fields.push({ name: `Can be used`, value: `**${numFmt(item.lasts)}** times` })
             fields.push({ name: `Cooldown`, value: `**${effect.cooldown}** hours` })
         }
         
@@ -243,7 +247,7 @@ const checks = {
             return `this guild already has **${item.name}**`
 
         if(user.exp < item.levels[0].price)
-            return `you need at least **${item.levels[0].price}** ${ctx.symbols.tomato} to build **${item.name} level 1**`
+            return `you need at least **${numFmt(item.levels[0].price)}** ${ctx.symbols.tomato} to build **${item.name} level 1**`
 
         if(XPtoLEVEL(guild.xp) < item.levels[0].level)
             return `this guild has to be at least level **${item.levels[0].level}** to have **${item.name} level 1**`
@@ -263,6 +267,7 @@ const checks = {
         if(!hub || hub.level < 3)
             return `you can create effect cards only in guild with **Smithing Hub level 3** or higher`
 
+        //Keeping this here in case we for some reason need to revert to not allowing stacking effects
         // if(user.effects.some(x => x.id === item.effectid && (x.expires || x.expires > now)))
         //     return `you already have this Effect Card`
     

--- a/modules/item.js
+++ b/modules/item.js
@@ -120,31 +120,45 @@ const uses = {
     },
 
     recipe: async (ctx, user, item) => {
+        let eobject, desc
         const check = checks.recipe(ctx, user, item)
         if(check)
             return ctx.reply(user, check, 'red')
 
-        const userEffect = user.effects.find(x => x.id === item.effectid)
+        let userEffect = user.effects.find(x => x.id === item.effectid)
         if(userEffect && userEffect.expires < new Date()) {
             user.heroslots = user.heroslots.filter(x => x != userEffect.id)
             user.effects = user.effects.filter(x => x.id != userEffect.id)
             user.markModified('heroslots')
             user.markModified('effects')
+            userEffect = false
         }
 
         const effect = ctx.effects.find(x => x.id === item.effectid)
-        const eobject = { id: item.effectid }
-        if(!effect.passive) { 
-            eobject.uses = item.lasts
-            eobject.cooldownends = new Date()
+        if (userEffect) {
+            eobject = userEffect
+            if(!effect.passive) {
+                eobject.uses += item.lasts
+            } else {
+                desc = `you already own this effect and it has never been equipped! You can only extend effects that have been equipped.`
+                if (!userEffect.expires)
+                    return ctx.reply(user, desc, 'red')
+                eobject.expires = asdate.add(userEffect.expires, item.lasts, 'days')
+            }
+            user.effects = user.effects.filter(x => x.id != userEffect.id)
+            desc = `you got **${effect.name}** ${effect.passive? 'passive':'usable'} Effect Card!
+                ${effect.passive? `The countdown timer on this effect has been extended. Find it in \`${ctx.prefix}hero slots\``:
+                `You have extended the number of uses for this effect. Your new usage limit is **${eobject.uses}**`}`
+        } else {
+            eobject = { id: item.effectid }
+            if(!effect.passive) {
+                eobject.uses = item.lasts
+                eobject.cooldownends = new Date()
+            }
+            desc = `you got **${effect.name}** ${effect.passive? 'passive':'usable'} Effect Card!
+                ${effect.passive? `To use this passive effect equip it with \`->hero equip [slot] ${effect.id}\``:
+                `Use this effect by typing \`->hero use ${effect.id}\`. Amount of uses is limited to **${item.lasts}**`}`
         }
-
-        item.cards.map(x => removeUserCard(ctx, user, x))
-        pullInventoryItem(user, item.id)
-        user.effects.push(eobject)
-        await user.save()
-        user.markModified('cards')
-        await user.save() //double for cards
 
         ctx.mixpanel.track(
             "Effect Craft", { 
@@ -153,13 +167,19 @@ const uses = {
                 is_passive: effect.passive,
         })
 
+        item.cards.map(x => removeUserCard(ctx, user, x))
+        pullInventoryItem(user, item.id)
+        user.effects.push(eobject)
+        await user.save()
+        user.markModified('cards')
+        await user.save() //double for cards
+
         return ctx.reply(user, {
             image: { url: `${ctx.baseurl}/effects/${effect.id}.gif` },
-            color: colors.blue,
-            description: `you got **${effect.name}** ${effect.passive? 'passive':'usable'} Effect Card!
-                ${effect.passive? `To use this passive effect equip it with \`->hero equip [slot] ${effect.id}\``:
-                `Use this effect by typing \`->hero use ${effect.id}\`. Amount of uses is limited to **${item.lasts}**`}`
-        })
+            description: desc
+        }, 'blue')
+
+
     }
 }
 
@@ -243,8 +263,8 @@ const checks = {
         if(!hub || hub.level < 3)
             return `you can create effect cards only in guild with **Smithing Hub level 3** or higher`
 
-        if(user.effects.some(x => x.id === item.effectid && (x.expires || x.expires > now)))
-            return `you already have this Effect Card`
+        // if(user.effects.some(x => x.id === item.effectid && (x.expires || x.expires > now)))
+        //     return `you already have this Effect Card`
     
         const effect = ctx.effects.find(x => x.id === item.effectid)
         if(!item.cards.reduce((val, x) => val && user.cards.some(y => y.id === x), true))

--- a/modules/preferences.js
+++ b/modules/preferences.js
@@ -43,7 +43,7 @@ const checkDaily = async (ctx) => {
 
     if(!userToDaily) return
 
-    await sendNotification(ctx, userToDaily, `Your daily is ready`, `you can claim you daily bonus now with \`->daily\`!`)
+    await sendNotification(ctx, userToDaily, `Your daily is ready`, `you can claim your daily bonus now with \`->daily\`!`)
     userToDaily.dailynotified = true
     await userToDaily.save()
 }

--- a/modules/transaction.js
+++ b/modules/transaction.js
@@ -7,6 +7,7 @@ const {
 
 const {
     generateNextId,
+    numFmt,
 } = require('../utils/tools')
 
 const {
@@ -90,7 +91,7 @@ const confirm_trs = async (ctx, user, trs_id) => {
             return ctx.reply(user, `you don't have rights to confirm this transaction`, 'red')
 
         if(to_user.exp < transaction.price)
-            return ctx.reply(to_user, `you need **${Math.floor(transaction.price - to_user.exp)}** ${ctx.symbols.tomato} more to confirm this transaction`, 'red')
+            return ctx.reply(to_user, `you need **${numFmt(Math.floor(transaction.price - to_user.exp))}** ${ctx.symbols.tomato} more to confirm this transaction`, 'red')
         
         to_user.exp -= transaction.price
 
@@ -135,10 +136,10 @@ const confirm_trs = async (ctx, user, trs_id) => {
     })*/
 
     if(to_user) {
-        return ctx.reply(from_user, `sold **${transaction.cards.length} card(s)** to **${transaction.to}** for **${transaction.price}** ${ctx.symbols.tomato}`)
+        return ctx.reply(from_user, `sold **${transaction.cards.length} card(s)** to **${transaction.to}** for **${numFmt(transaction.price)}** ${ctx.symbols.tomato}`)
     }
 
-    return ctx.reply(user, `sold **${transaction.cards.length} card(s)** to **${transaction.to}** for **${transaction.price}** ${ctx.symbols.tomato}`)
+    return ctx.reply(user, `sold **${transaction.cards.length} card(s)** to **${transaction.to}** for **${numFmt(transaction.price)}** ${ctx.symbols.tomato}`)
 }
 
 const decline_trs = async (ctx, user, trs_id) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "amusementclub2.0",
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
@@ -27,7 +26,8 @@
         "mixpanel": "^0.13.0",
         "mongodb": "^3.5.2",
         "mongoose": "^5.8.11",
-        "pretty-ms": "^5.1.0"
+        "pretty-ms": "^5.1.0",
+        "thenby": "^1.3.4"
       }
     },
     "node_modules/@top-gg/sdk": {
@@ -353,8 +353,6 @@
       "resolved": "https://registry.npmjs.org/eris/-/eris-0.11.2.tgz",
       "integrity": "sha512-OhccRcxrPiNUylTamrjIbZM6itKMLjNrwLIXGvNwQZj4CRVOOz9eUVIqOJULB713x1ezw7HoC8AEsnsMNUneDA==",
       "dependencies": {
-        "opusscript": "^0.0.7",
-        "tweetnacl": "^1.0.1",
         "ws": "^7.2.1"
       },
       "engines": {
@@ -670,8 +668,7 @@
         "bson": "^1.1.1",
         "denque": "^1.4.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
         "node": ">=4"
@@ -713,8 +710,7 @@
       "dependencies": {
         "bson": "^1.1.1",
         "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2",
-        "saslprep": "^1.0.0"
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
         "node": ">=4"
@@ -1048,6 +1044,11 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ=="
     },
     "node_modules/toidentifier": {
       "version": "1.0.0",
@@ -1974,6 +1975,11 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
+    },
+    "thenby": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/thenby/-/thenby-1.3.4.tgz",
+      "integrity": "sha512-89Gi5raiWA3QZ4b2ePcEwswC3me9JIg+ToSgtE0JWeCynLnLxNr/f9G+xfo9K+Oj4AFdom8YNJjibIARTJmapQ=="
     },
     "toidentifier": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mixpanel": "^0.13.0",
     "mongodb": "^3.5.2",
     "mongoose": "^5.8.11",
-    "pretty-ms": "^5.1.0"
+    "pretty-ms": "^5.1.0",
+    "thenby": "^1.3.4"
   }
 }

--- a/staticdata/achievements.js
+++ b/staticdata/achievements.js
@@ -49,7 +49,7 @@ module.exports = [
             user.exp += 10000
             user.vials += 1000
             user.xp += 100
-            return `**10000** ${ctx.symbols.tomato} and **1000** ${ctx.symbols.vial}`
+            return `**10,000** ${ctx.symbols.tomato} and **1,000** ${ctx.symbols.vial}`
         }
     }, {
         id: 'firstforge',

--- a/staticdata/effects.js
+++ b/staticdata/effects.js
@@ -45,6 +45,11 @@ module.exports = [
         name: 'Impossible Spell Card',
         desc: 'Usable effects have 40% less cooldown',
         passive: true
+    }, {
+        id: 'festivewish',
+        name: 'Festival of Wishes',
+        desc: 'Get notified when a card on your wishlist is auctioned',
+        passive: true
     },
 
     {

--- a/staticdata/items.json
+++ b/staticdata/items.json
@@ -250,6 +250,16 @@
         "fulldesc": "When used gives you **Impossible Spell Card**. This is a passive item, so make sure you equip it into hero's effect card slot",
         "recipe": [2, 2, 2, 3, 3, 3],
         "lasts": 20
+    }, {
+        "id": "festivewish",
+        "effectid": "festivewish",
+        "name": "Festival of Wishes",
+        "price": 3000,
+        "type": "recipe",
+        "desc": "wishlist auc notifications",
+        "fulldesc": "When used gives you **Festival of Wishes** effect card. This is a passive item, so make sure you equip it into hero's effect card slot",
+        "recipe": [1, 1, 1, 1],
+        "lasts": 30
     },
 
     {

--- a/staticdata/quests.js
+++ b/staticdata/quests.js
@@ -25,7 +25,7 @@ module.exports = {
                 user.exp += 1400
                 user.xp += 5
             },
-            reward: (ctx) => `**1400** ${ctx.symbols.tomato} and **5** xp`
+            reward: (ctx) => `**1,400** ${ctx.symbols.tomato} and **5** xp`
         }, {
             id: 'bid2',
             name: 'Bid on 2 auctions today',
@@ -38,7 +38,7 @@ module.exports = {
                 user.exp += 1000
                 user.xp += 2
             },
-            reward: (ctx) => `**1000** ${ctx.symbols.tomato} and **2** xp`
+            reward: (ctx) => `**1,000** ${ctx.symbols.tomato} and **2** xp`
         }, {
             id: 'bid5',
             name: 'Bid on 4 auctions today',
@@ -51,7 +51,7 @@ module.exports = {
                 user.exp += 2000
                 user.xp += 8
             },
-            reward: (ctx) => `**2000** ${ctx.symbols.tomato} and **8** xp`
+            reward: (ctx) => `**2,000** ${ctx.symbols.tomato} and **8** xp`
         }, {
             id: 'forge1',
             name: 'Forge 1-star card',
@@ -95,7 +95,7 @@ module.exports = {
                 user.vials += 40
                 user.xp += 5
             },
-            reward: (ctx) => `**1000** ${ctx.symbols.tomato}, **40** ${ctx.symbols.vial} and **5** xp`
+            reward: (ctx) => `**1,000** ${ctx.symbols.tomato}, **40** ${ctx.symbols.vial} and **5** xp`
         }, {
             id: 'tag2',
             name: 'Tag 2 cards',
@@ -150,7 +150,7 @@ module.exports = {
                 user.vials += 60
                 user.xp += 3
             },
-            reward: (ctx) => `**1500** ${ctx.symbols.tomato}, **60** ${ctx.symbols.vial} and **3** xp`
+            reward: (ctx) => `**1,500** ${ctx.symbols.tomato}, **60** ${ctx.symbols.vial} and **3** xp`
         },
     ],
 

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -92,6 +92,10 @@ const generateNextId = (lastId, idLength = 4) => {
     return nextId;
 }
 
+const numFmt = (number) => {
+    return number.toLocaleString('en-US')
+}
+
 //const XPtoLEVEL = (xp) => xp === 0? 0 : Math.max(Math.floor((Math.log(xp) / Math.log(5)) * Math.sqrt(xp) * .75), 0)
 const XPtoLEVEL = (xp) => Math.floor(Math.sqrt(xp * 2))
 
@@ -112,5 +116,6 @@ module.exports = {
     XPtoLEVEL,
     LEVELtoXP,
     arrayChunks,
-    escapeRegex
+    escapeRegex,
+    numFmt
 }


### PR DESCRIPTION
Added full "auction" as an alias to auc

Created a new time formatter for auction time readouts as it was a little too accurate before.

Fixed undefined in find user

changed ->wish to become ->wish add, and changed ->wish to ->wish list or ->wish ls

Minor text changes on set and unset bot as well as help prompt

ls shows tomato eval if you do eval sort query, may get removed later

added pat as a bypass command, and set prefix in context to curprefix

re-arranged finish aucs to prioritize getting cards and tomatoes to people before anything else, so as to hopefully avoid auction issues we have been having

brand new sort system for queries, supports multi sorts in order typed

also added the -wish query

made it so if you create an effect while already owning it, it will now add uses/time to the effect instead of yelling because you already own it

now define default prefix on guild add