### PR TITLE
Eval Bugfix, Allowable Plots Fix, Audit User Tag Fix

### DIFF
--- a/commands/audit.js
+++ b/commands/audit.js
@@ -210,7 +210,7 @@ pcmd(['admin', 'mod', 'auditor', 'tagmod'], ['audit', 'user', 'tags'], withGloba
     if (!ctx.audit.channel.includes(ctx.msg.channel.id))
         return ctx.reply(user, 'This command can only be run in an audit channel.', 'red')
 
-    if (!arg.ids)
+    if (arg.ids.length === 0)
         return ctx.reply(user, `please submit a valid user ID`, 'red')
 
     const auditedUser = await fetchOnly(arg.ids)

--- a/modules/eval.js
+++ b/modules/eval.js
@@ -131,7 +131,7 @@ const getEval = (ctx, card, ownerCount, modifier = 1) => {
         let priceFloor = Math.round((((ctx.eval.cardPrices[card.level] + (card.animated? 100 : 0))
             * limitPriceGrowth((allUsers * ctx.eval.evalUserRate) / ownerCount)) * 0.689) * modifier)
 
-        price = (info.aucevalinfo.evalprices.reduce((a, b) => a + b) / info.aucevalinfo.evalprices.length)
+        price = Math.round(info.aucevalinfo.evalprices.reduce((a, b) => a + b) / info.aucevalinfo.evalprices.length)
 
         if (price < priceFloor)
             price = priceFloor

--- a/utils/tools.js
+++ b/utils/tools.js
@@ -24,6 +24,16 @@ const promoClaimCost = (user, amount, totalClaims) => {
     return Math.round(total)
 }
 
+const plotBuyCost = (user, amount, totalPlots) => {
+    let total = 0
+    let plots = totalPlots || 0
+    for (let i = 0; i < amount; i++) {
+        plots++
+        total += plots * 50
+    }
+    return Math.round(total)
+}
+
 const tryGetUserID = (inp) => {
     inp = inp.trim()
 
@@ -117,5 +127,6 @@ module.exports = {
     LEVELtoXP,
     arrayChunks,
     escapeRegex,
-    numFmt
+    numFmt,
+    plotBuyCost
 }


### PR DESCRIPTION
Returned the Math.round to eval, it somehow disappeared but the () remained

Changed the message return when buying a plot to let the user know how many plots they can buy based on lemon balance, user level cap, and guild level cap

Fixed running `->audit user tags` without an ID causing an error instead of returning an error notice to user