### PR TITLE
Limit boost info to 1024 per page, fix audit guild pagination

### DIFF
--- a/commands/audit.js
+++ b/commands/audit.js
@@ -252,7 +252,7 @@ pcmd(['admin', 'auditor'], ['audit', 'guild'], async (ctx, user, ...args) => {
 
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-        pages: paginate_guildtrslist(ctx, user, list),
+        pages: paginateGuildTrsList(ctx, user, list),
         buttons: ['back', 'forward'],
         embed: {
             author: { name: `${user.username}, here are the guild transactions for \`${arg.id}\` (${list.length} results)` },

--- a/commands/card.js
+++ b/commands/card.js
@@ -567,7 +567,7 @@ cmd(['boost', 'info'], (ctx, user, args) => {
     list.push(`Expires in **${msToTime(boost.expires - now)}**`)
 
     return ctx.pgn.addPagination(user.discord_id, ctx.msg.channel.id, {
-        pages: ctx.pgn.getPages(boost.cards.map(c => formatName(ctx.cards[c])), 10),
+        pages: ctx.pgn.getPages(boost.cards.map(c => formatName(ctx.cards[c])), 10, 1024),
         switchPage: (data) => data.embed.fields[0].value = data.pages[data.pagenum],
         embed: {
             author: { name: `${boost.name} boost` },


### PR DESCRIPTION
boost info uses fields for info display, which has a limit of 1024 instead of the default 4096 for descriptions